### PR TITLE
投稿作成ページ

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -13,7 +13,7 @@ class PostsController < ApplicationController
 
   def create
     @post = Post.new(post_params)
-    @post.user = current_user 
+    @post.user = current_user
     if @post.save
       redirect_to post_path(@post)
     else

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,4 +6,24 @@ class PostsController < ApplicationController
   def show
     @post = Post.find(params[:id])
   end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = Post.new(post_params)
+    @post.user = current_user 
+    if @post.save
+      redirect_to post_path(@post)
+    else
+      puts @post.errors.full_messages
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def post_params
+    params.require(:post).permit(:cafe_name, :body, :address, :cafe_link)
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,22 +1,28 @@
 <div class="bg-cream">
-<div class="container mx-auto">
-  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">
-    <% @posts.each do |post| %>
-      <div class="rounded-lg overflow-hidden bg-white">
-        <%= image_tag 'eyecatch.png', class: 'h-48 w-full object-cover' %>
-        <div class="p-4">
-          <h2 class="mb-2">
-            <%= link_to post.cafe_name, post_path(post), class: 'text-brown hover:opacity-70 text-16 font-bold' %>
-          </h2>
-          <div class="mt-2">
-            <p class="font-semibold text-14 text-gray-700">mayuko0000</p>
-            <p class="text-gray-500 text-14">
-              <%= post.created_at %>
-            </p>
+  <div class="container mx-auto">
+    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">
+      <% @posts.each do |post| %>
+        <div class="rounded-lg overflow-hidden bg-white">
+          <%= image_tag 'eyecatch.png', class: 'h-48 w-full object-cover' %>
+          <div class="p-4">
+            <h2 class="mb-2">
+              <%= link_to post.cafe_name, post_path(post), class: 'text-brown hover:opacity-70 text-16 font-bold' %>
+            </h2>
+            <div class="mt-2">
+              <p class="font-semibold text-14 text-gray-700">mayuko0000</p>
+              <p class="text-gray-500 text-14">
+                <%= post.created_at %>
+              </p>
+            </div>
           </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
+  <%= link_to new_post_path do %>
+  <div class="bg-teal border-44 border-white p-4 rounded-full shadow-lg fixed bottom-2 right-2 flex items-center justify-center w-16 h-16">
+    <i class="fa fa-plus text-white text-2xl"></i>
+  </div>
+<% end %>
+
 </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,30 @@
+<body class="bg-cream">
+<div class="container mx-auto mt-8 mb-12 px-32 py-6">
+  <%= form_with(model: @post, url: posts_path, method: 'post', local: true) do |f| %>
+    <div class="mb-4">
+      <%= f.label :cafe_name, 'カフェ名', class: 'block text-brown font-semibold mb-2' %>
+      <%= f.text_field :cafe_name, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+    </div>
+
+    <div class="mb-4">
+      <%= f.label :body, '内容', class: 'block text-brown font-semibold mb-2' %>
+      <%= f.text_area :body, class: 'border border-gray-200 rounded-lg w-full p-2 h-32' %>
+    </div>
+
+    <div class="mb-4">
+      <%= f.label :address, '住所', class: 'block text-brown font-semibold mb-2' %>
+      <%= f.text_field :address, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+    </div>
+
+    <div class="mb-4">
+      <%= f.label :cafe_link, 'URL', class: 'block text-brown font-semibold mb-2' %>
+      <%= f.text_field :cafe_link, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+    </div>
+
+   <div class="flex justify-center">
+  <%= f.submit '投稿する', class: 'bg-teal text-white font-bold mt-8 py-2 px-12 rounded-lg hover:bg-opacity-70 max-w-xs' %>
+</div>
+  <% end %>
+</div>
+
+</body>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,30 +1,29 @@
 <body class="bg-cream">
-<div class="container mx-auto mt-8 mb-12 px-32 py-6">
-  <%= form_with(model: @post, url: posts_path, method: 'post', local: true) do |f| %>
-    <div class="mb-4">
-      <%= f.label :cafe_name, 'カフェ名', class: 'block text-brown font-semibold mb-2' %>
-      <%= f.text_field :cafe_name, class: 'border border-gray-200 rounded-lg w-full p-2' %>
-    </div>
+  <div class="container mx-auto mt-8 mb-12 px-32 py-6">
+    <%= form_with(model: @post, url: posts_path, method: 'post', local: true) do |f| %>
+      <div class="mb-4">
+        <%= f.label :cafe_name, 'カフェ名', class: 'block text-brown font-semibold mb-2' %>
+        <%= f.text_field :cafe_name, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+      </div>
 
-    <div class="mb-4">
-      <%= f.label :body, '内容', class: 'block text-brown font-semibold mb-2' %>
-      <%= f.text_area :body, class: 'border border-gray-200 rounded-lg w-full p-2 h-32' %>
-    </div>
+      <div class="mb-4">
+        <%= f.label :body, '内容', class: 'block text-brown font-semibold mb-2' %>
+        <%= f.text_area :body, class: 'border border-gray-200 rounded-lg w-full p-2 h-32' %>
+      </div>
 
-    <div class="mb-4">
-      <%= f.label :address, '住所', class: 'block text-brown font-semibold mb-2' %>
-      <%= f.text_field :address, class: 'border border-gray-200 rounded-lg w-full p-2' %>
-    </div>
+      <div class="mb-4">
+        <%= f.label :address, '住所', class: 'block text-brown font-semibold mb-2' %>
+        <%= f.text_field :address, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+      </div>
 
-    <div class="mb-4">
-      <%= f.label :cafe_link, 'URL', class: 'block text-brown font-semibold mb-2' %>
-      <%= f.text_field :cafe_link, class: 'border border-gray-200 rounded-lg w-full p-2' %>
-    </div>
+      <div class="mb-4">
+        <%= f.label :cafe_link, 'URL', class: 'block text-brown font-semibold mb-2' %>
+        <%= f.text_field :cafe_link, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+      </div>
 
-   <div class="flex justify-center">
-  <%= f.submit '投稿する', class: 'bg-teal text-white font-bold mt-8 py-2 px-12 rounded-lg hover:bg-opacity-70 max-w-xs' %>
-</div>
-  <% end %>
-</div>
-
+      <div class="flex justify-center">
+        <%= f.submit '投稿する', class: 'bg-teal text-white font-bold mt-8 py-2 px-12 rounded-lg hover:bg-opacity-70 max-w-xs' %>
+      </div>
+    <% end %>
+  </div>
 </body>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -30,5 +30,10 @@
         <%= link_to @post.cafe_link, @post.cafe_link, target: "_blank", rel: "noopener noreferrer" %>
       </p>
     </div>
+     <%= link_to new_post_path do %>
+      <div class="bg-teal border-4 border-white p-4 rounded-full shadow-lg fixed bottom-2 right-2 flex items-center justify-center w-16 h-16">
+        <i class="fa fa-plus text-white text-2xl"></i>
+      </div>
+    <% end %>
   </div>
 </body>


### PR DESCRIPTION
### 概要
投稿詳細ページの作成(`post/new`・`post/create`)
***

### 変更内容
- ルーティング・コントローラ・ビューの作成（`post/new`・`post/create`）
- tailwindの追加
- 投稿作成画面に遷移するボタンを投稿一覧画面と投稿詳細画面に追加

***

### 影響
投稿作成画面から投稿が可
（投稿一覧画面もしく投稿詳細画面から右下の＋ボタンをクリックすると投稿作成ページへと繋がる）
***

### 関連イシュー
#18 　投稿作成ページ
***