### PR TITLE
投稿編集ページ

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,6 +22,19 @@ class PostsController < ApplicationController
     end
   end
 
+  def edit
+    @post = Post.find(params[:id])
+  end
+
+  def update
+    @post = Post.find(params[:id])
+    if @post.update(post_params)
+      redirect_to post_path(@post)
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
   private
   def post_params
     params.require(:post).permit(:cafe_name, :body, :address, :cafe_link)

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,29 @@
+<body class="bg-cream">
+  <div class="container mx-auto mt-8 mb-12 px-32 py-6">
+    <%= form_with(model: @post, url: post_path(@post), method: 'put', local: true) do |f| %>
+        <div class="mb-4">
+          <%= f.label :cafe_name, 'カフェ名', class: 'block text-brown font-semibold mb-2' %>
+          <%= f.text_field :cafe_name, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :body, '内容', class: 'block text-brown font-semibold mb-2' %>
+          <%= f.text_area :body, class: 'border border-gray-200 rounded-lg w-full p-2 h-32' %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :address, '住所', class: 'block text-brown font-semibold mb-2' %>
+          <%= f.text_field :address, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+        </div>
+
+        <div class="mb-4">
+          <%= f.label :cafe_link, 'URL', class: 'block text-brown font-semibold mb-2' %>
+          <%= f.text_field :cafe_link, class: 'border border-gray-200 rounded-lg w-full p-2' %>
+        </div>
+
+        <div class="flex justify-center">
+          <%= f.submit '更新する', class: 'bg-teal text-white font-bold mt-8 py-2 px-12 rounded-lg hover:bg-opacity-70 max-w-xs' %>
+        </div>
+    <% end %>
+  </div>
+</body>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -20,7 +20,7 @@
     </div>
   </div>
   <%= link_to new_post_path do %>
-  <div class="bg-teal border-44 border-white p-4 rounded-full shadow-lg fixed bottom-2 right-2 flex items-center justify-center w-16 h-16">
+  <div class="bg-teal border-4 border-white p-4 rounded-full shadow-lg fixed bottom-2 right-2 flex items-center justify-center w-16 h-16">
     <i class="fa fa-plus text-white text-2xl"></i>
   </div>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -5,7 +5,7 @@
 
       <div class="flex items-center">
         <% if current_user&.mine?(@post) %>
-          <%= image_tag 'edit.png', class: 'w-6 h-6 mr-2 cursor-pointer' %>
+          <%= link_to image_tag('edit.png', class: 'w-6 h-6 mr-2 cursor-pointer'), edit_post_path(@post) %>
           <%= image_tag 'destroy.png', class: 'w-6 h-6 cursor-pointer' %>
         <% else %>
           <%= image_tag 'bookmark.png', class: 'w-6 h-6 cursor-pointer' %>


### PR DESCRIPTION
### 概要
投稿編集ページの作成(`post/edit`・`post/update`)
***

### 変更内容
- ルーティング・コントローラ・ビューの作成（`post/edit`・`post/update`）
- tailwindの追加
- 投稿編集画面に遷移するように投稿詳細画面の編集ボタンにパスを追加

***

### 影響
投稿詳細画面の編集ボタンから投稿編集が可能
***

### 関連イシュー
#22 　投稿編集ページ
***