### PR TITLE
投稿削除機能

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,6 +35,12 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    post = current_user.posts.find(params[:id])
+    post.destroy!
+    redirect_to posts_path
+  end
+
   private
   def post_params
     params.require(:post).permit(:cafe_name, :body, :address, :cafe_link)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,7 +6,7 @@
       <div class="flex items-center">
         <% if current_user&.mine?(@post) %>
           <%= link_to image_tag('edit.png', class: 'w-6 h-6 mr-2 cursor-pointer'), edit_post_path(@post) %>
-          <%= image_tag 'destroy.png', class: 'w-6 h-6 cursor-pointer' %>
+          <%= link_to image_tag('destroy.png', class: 'w-6 h-6 cursor-pointer'), post_path(@post), data: { turbo_method: :delete, turbo_confirm: ('削除しますか？') } %>
         <% else %>
           <%= image_tag 'bookmark.png', class: 'w-6 h-6 cursor-pointer' %>
         <% end %>


### PR DESCRIPTION
### 概要
投稿削除機能の追加(`post/destroy`)
***
### 変更内容
- コントローラの作成（`post/destroy`）
- 投稿詳細画面から投稿削除が行えるように削除ボタンにパスを追加

***
### 影響
投稿詳細画面の削除ボタンから投稿削除が可能
***
### 関連イシュー
#23 　投稿削除機能
***