### PR TITLE
postモデルのimageアップロード画像追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -44,6 +44,6 @@ class PostsController < ApplicationController
 
   private
   def post_params
-    params.require(:post).permit(:cafe_name, :body, :address, :cafe_link)
+    params.require(:post).permit(:cafe_name, :body, :address, :cafe_link, :image)
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -5,4 +5,5 @@ class Post < ApplicationRecord
   validates :cafe_link, format: { with: URI::regexp(%w[http https]), allow_blank: true }
 
   belongs_to :user
+  has_one_attached :image
 end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -17,6 +17,11 @@
         </div>
 
         <div class="mb-4">
+          <%= f.label :image, 'アップロード画像', class: 'block text-brown font-semibold mb-2'%>
+          <%= f.file_field :image, accept: "image/*", class: 'border border-gray-200 rounded-lg w-full p-2 bg-white'%>
+        </div>
+
+        <div class="mb-4">
           <%= f.label :address, '住所', class: 'block text-brown font-semibold mb-2' %>
           <%= f.text_field :address, class: 'border border-gray-200 rounded-lg w-full p-2' %>
         </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -17,6 +17,11 @@
       </div>
 
       <div class="mb-4">
+        <%= f.label :image, 'アップロード画像', class: 'block text-brown font-semibold mb-2' %>
+        <%= f.file_field :image, accept: "image/*", class: 'border border-gray-200 rounded-lg w-full p-2 bg-white' %>
+      </div>
+
+      <div class="mb-4">
         <%= f.label :address, '住所', class: 'block text-brown font-semibold mb-2' %>
         <%= f.text_field :address, class: 'border border-gray-200 rounded-lg w-full p-2' %>
       </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -17,6 +17,10 @@
 
     <p class="text-gray-700 mb-8"><%= @post.body %></p>
 
+    <% if @post.image.attached? %>
+      <%= image_tag @post.image, class: 'w-96 h-auto mb-8' %>  <!-- 画像を表示 -->
+    <% end %>
+
     <div class="flex items-center mb-2">
       <%= image_tag 'address.png', class: 'w-6 h-6 mr-2' %>
       <p class="text-gray-700">

--- a/db/migrate/20241011235855_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20241011235855_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_10_065212) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_11_235855) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -36,4 +64,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_10_065212) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
### 概要
postモデルのimageカラム追加（Active Storage）
***
### 変更内容
-  `rails active_storage:install`でactive_storageをインストールする
-  モデルに `has_one_attached :image`を追加
-  postコントローラのstrongparamsに`image`を追加
***
### 影響
投稿作成時・投稿編集時に画像を追加できる
***
### 関連イシュー
#72　投稿 画像アップロード
***