### PR TITLE
コメント編集ページの追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -34,7 +34,6 @@ class CommentsController < ApplicationController
     end
   end
 
-
   private
   def comment_params
     params.require(:comment).permit(:content)

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,14 +6,34 @@ class CommentsController < ApplicationController
 
   def create
     post = Post.find(params[:post_id])
-    @comment = post.comments.build(comment_params.merge(user: current_user)) # userを設定
+    @comment = post.comments.build(comment_params.merge(user: current_user))
+
     if @comment.save
       redirect_to post_path(post), notice: 'コメントを追加'
     else
+      puts @comment.errors.full_messages  # エラーメッセージを出力
       flash.now[:error] = 'コメントを追加できませんでした'
       render :new
     end
   end
+
+  def edit
+    @post = Post.find(params[:post_id])
+    @comment = @post.comments.find(params[:id])
+  end
+
+  def update
+    @post = Post.find(params[:post_id])
+    @comment = @post.comments.find(params[:id])
+
+    if @comment.update(comment_params)
+      redirect_to post_path(@post), notice: 'コメントを更新しました。'
+    else
+      flash.now[:error] = '更新できませんでした。'
+      render :edit
+    end
+  end
+
 
   private
   def comment_params

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,6 +5,7 @@ class PostsController < ApplicationController
 
   def show
     @post = Post.find(params[:id])
+    @comment = Comment.new
     @comments = @post.comments
   end
 

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -1,6 +1,6 @@
 <body class="bg-cream">
   <div class="container mx-auto mt-8 mb-12 px-32 py-6">
-    <%= form_with(model: @comment, url: post_comments_path(@comment.post), local: true) do |f| %>
+    <%= form_with model: [@post, @comment], local: true do |f| %>
       <div>
         <%= f.label :content, 'コメント本文', class: 'block text-brown font-semibold mb-2' %>
       </div>
@@ -9,7 +9,7 @@
       </div>
       <div class="flex justify-center">
         <%= f.submit '投稿する', class: 'bg-teal text-white font-bold mt-8 py-2 px-12 rounded-lg hover:bg-opacity-70 max-w-xs' %>
+      </div>
     <% end %>
-    </div>
   </div>
 </body>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,11 +2,10 @@
   <div class="container mx-auto px-20 py-16 my-8 bg-white rounded-xl">
     <div class="flex justify-between items-center mb-4">
       <h1 class="text-2xl font-bold text-brown"><%= @post.cafe_name %></h1>
-
       <div class="flex items-center">
         <% if current_user&.mine?(@post) %>
           <%= link_to image_tag('edit.png', class: 'w-6 h-6 mr-2 cursor-pointer'), edit_post_path(@post) %>
-          <%= link_to image_tag('destroy.png', class: 'w-6 h-6 cursor-pointer'), post_path(@post), data: { turbo_method: :delete, turbo_confirm: ('削除しますか？') } %>
+          <%= link_to image_tag('destroy.png', class: 'w-6 h-6 cursor-pointer'), post_path(@post), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } %>
         <% else %>
           <%= image_tag 'bookmark.png', class: 'w-6 h-6 cursor-pointer' %>
         <% end %>
@@ -14,57 +13,49 @@
     </div>
 
     <p class="text-gray-500 text-14 mb-2"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
-
     <p class="text-gray-700 mb-8"><%= @post.body %></p>
 
     <% if @post.image.attached? %>
-      <%= image_tag @post.image, class: 'w-96 h-auto mb-8' %>  <!-- 画像を表示 -->
+      <%= image_tag @post.image, class: 'w-96 h-auto mb-8' %>
     <% end %>
 
     <div class="flex items-center mb-2">
       <%= image_tag 'address.png', class: 'w-6 h-6 mr-2' %>
-      <p class="text-gray-700">
-        <%= @post.address %>
-      </p>
+      <p class="text-gray-700"><%= @post.address %></p>
     </div>
 
     <div class="flex items-center mb-8">
       <%= image_tag 'link.png', class: 'w-6 h-6 mr-2' %>
-      <p class="text-gray-700">
-        <%= link_to @post.cafe_link, @post.cafe_link, target: "_blank", rel: "noopener noreferrer" %>
-      </p>
+      <p class="text-gray-700"><%= link_to @post.cafe_link, @post.cafe_link, target: "_blank", rel: "noopener noreferrer" %></p>
     </div>
 
-    <%= link_to new_post_path do %>
+    <%= link_to do %>
       <div class="bg-teal border-4 border-white p-4 rounded-full shadow-lg fixed bottom-2 right-2 flex items-center justify-center w-16 h-16">
         <i class="fa fa-plus text-white text-2xl"></i>
       </div>
     <% end %>
 
     <%= link_to new_post_comment_path(@post) do %>
-  <div class="flex items-center mb-12">
-    <%= image_tag 'comment.png', alt: 'コメントアイコン', class: 'w-6 h-6 mr-2' %>
-    <div class="text-gray-700 font-bold">
-      コメントを追加する
-    </div>
-  </div>
-<% end %>
+      <div class="flex items-center mb-12">
+        <%= image_tag 'comment.png', alt: 'コメントアイコン', class: 'w-6 h-6 mr-2' %>
+        <div class="text-gray-700 font-bold">コメントを追加する</div>
+      </div>
+    <% end %>
 
-  <div class="bg-cream p-2 rounded-xl">
-  <h2 class="text-brown text-20 font-bold p-2">コメント一覧</h2>
-  <% @comments.each do |comment| %>
-    <div class="flex items-center text-gray-600 bg-white px-16 py-4 m-4 rounded-xl">
-      <p class="flex-1"><%= comment.content %></p>
-      <span class="text-gray-500 text-14 ml-12 mr-2"><%= comment.user.display_name %></span>
-
-       <% if current_user == comment.user %>
-        <div class="ml-4 flex space-x-2"> <!-- Flexboxを使って横並びに -->
-          <%= link_to image_tag('edit.png', alt: 'Edit', class: 'w-4 h-4'), '#' %>
-          <%= link_to image_tag('destroy.png', alt: 'Delete', class: 'w-4 h-4'), '#' %>
+    <div class="bg-cream p-2 rounded-xl">
+      <h2 class="text-brown text-20 font-bold p-2">コメント一覧</h2>
+      <% @comments.each do |comment| %>
+        <div class="flex items-center text-gray-600 bg-white px-16 py-4 m-4 rounded-xl">
+          <p class="flex-1"><%= comment.content %></p>
+          <span class="text-gray-500 text-14 ml-12 mr-2"><%= comment.user.display_name %></span>
+          <% if current_user == comment.user %>
+            <div class="ml-4 flex space-x-2">
+              <%= link_to image_tag('edit.png', alt: 'Edit', class: 'w-4 h-4'), edit_post_comment_path(@post, comment) %>
+              <%= link_to image_tag('destroy.png', alt: 'Delete', class: 'w-4 h-4'), '#' %>
+            </div>
+          <% end %>
         </div>
       <% end %>
     </div>
-  <% end %>
-</div>
   </div>
 </body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   root to: 'posts#index'
   resources :posts do
-    resources :comments, only: [:new, :create]
+    resources :comments, only: [:new, :create, :edit, :update]
   end
   # Defines the root path route ("/")
   # root "posts#index"


### PR DESCRIPTION
### 概要
投稿詳細画面にコメント編集ページの追加（`comment/edit`・`comment/update`）
***
### 変更内容
- ルーティング・コントローラ・ビューの作成（`comment/edit`・`comment/update`・`post/show`）
***
### 影響

- 投稿詳細画面からコメント編集が可能
- 編集したコメントは投稿詳細ページに更新される

***
### 関連イシュー
#25 コメント編集ページ
***