### PR TITLE
コメント削除機能の追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -34,6 +34,14 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    @post = Post.find(params[:post_id])
+    @comment = @post.comments.find(params[:id])
+    @comment.destroy
+    flash[:notice] = 'コメントが削除されました。'
+    redirect_to @post
+  end
+
   private
   def comment_params
     params.require(:comment).permit(:content)

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -36,7 +36,7 @@
     <% end %>
 
     <%= link_to new_post_comment_path(@post) do %>
-      <div class="flex items-center mb-12">
+      <div class="flex items-center mb-8">
         <%= image_tag 'comment.png', alt: 'コメントアイコン', class: 'w-6 h-6 mr-2' %>
         <div class="text-gray-700 font-bold">コメントを追加する</div>
       </div>
@@ -49,10 +49,10 @@
           <p class="flex-1"><%= comment.content %></p>
           <span class="text-gray-500 text-14 ml-12 mr-2"><%= comment.user.display_name %></span>
           <% if current_user == comment.user %>
-            <div class="ml-4 flex space-x-2">
-              <%= link_to image_tag('edit.png', alt: 'Edit', class: 'w-4 h-4'), edit_post_comment_path(@post, comment) %>
-              <%= link_to image_tag('destroy.png', alt: 'Delete', class: 'w-4 h-4'), '#' %>
-            </div>
+            <div class="ml-4 flex items-center space-x-2">
+              <%= link_to image_tag('edit.png', alt: 'Edit', class: 'w-4 h-4'), edit_post_comment_path(@post, comment), class: 'btn' %>
+              <%= button_to image_tag("destroy.png", alt: "削除", class: 'w-4 h-4 mt-1'), post_comment_path(comment.post.id, comment.id), method: :delete %>
+          </div>
           <% end %>
         </div>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
 
   root to: 'posts#index'
   resources :posts do
-    resources :comments, only: [:new, :create, :edit, :update]
+    resources :comments, only: [:new, :create, :edit, :update, :destroy]
   end
   # Defines the root path route ("/")
   # root "posts#index"


### PR DESCRIPTION
### 概要
投稿詳細画面にコメント編集ページの追加（`comment/destroy`）
***
### 変更内容
- ルーティング・コントローラ・ビューの作成（`comment/destroy`・`post/show`）
***
### 影響

- 投稿詳細画面からコメント削除が可能

***
### 関連イシュー
#26 コメント削除機能
***