### PR TITLE
profileモデルのavatar画像追加

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -24,6 +24,6 @@ class ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.require(:profile).permit(:nickname, :birthday, :mbti, :address, :introduction, :x_link, :instagram_link)
+    params.require(:profile).permit(:nickname, :birthday, :mbti, :address, :introduction, :x_link, :instagram_link, :avatar)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -8,4 +8,5 @@ class Profile < ApplicationRecord
    validates :instagram_link, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: 'は有効なURLである必要があります' }, allow_blank: true
 
   belongs_to :user
+  has_one_attached :avatar
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -8,6 +8,11 @@
       </div>
 
       <div class="mb-4">
+        <%= f.label :avatar, 'プロフィール画像', class: 'block text-brown font-semibold mb-2' %>
+        <%= f.file_field :avatar, accept: "avatar/*", class: 'border border-gray-200 rounded-lg w-full p-2 bg-white' %>
+      </div>
+
+      <div class="mb-4">
         <%= f.label :birthday, '生年月日', class: 'block text-brown font-semibold mb-2' %>
         <%= f.date_field :birthday, class: 'border border-gray-200 rounded-lg w-full p-2'%>
       </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -2,7 +2,9 @@
   <div class="container mt-6 mx-auto p-4 flex justify-center">
     <div class="flex flex-col items-center bg-white rounded-lg p-10">
       <div class="flex items-center space-x-4 mb-4">
-        <%= image_tag 'profile.png', class: 'w-10 h-10 rounded-full' %>
+        <% if @profile.avatar.attached? %>
+          <%= image_tag @profile.avatar, class: 'w-12 h-12 mr-2 border rounded-full' %>
+        <% end %>
         <div>
           <h2 class="text-xl text-brown font-semibold">
             <%= @profile&.nickname.presence || current_user.display_name %>


### PR DESCRIPTION
### 概要
profileモデルのavatarカラム追加（Active Storage）
***
### 変更内容
-  モデルに `has_one_attached :avatar`を追加
-  postコントローラのstrongparamsに`avatar`を追加
- ビューの作成
***
### 影響
プロフィール作成時・編集時に画像を追加できる
***
### 関連イシュー
#79  プロフィール 画像アップロード
***