### PR TITLE
投稿画像を該当ビューに表示

### DIFF
--- a/app/views/commons/_post.html.erb
+++ b/app/views/commons/_post.html.erb
@@ -1,5 +1,10 @@
 <div class="rounded-lg overflow-hidden bg-white">
-  <%= image_tag 'eyecatch.png', class: 'h-48 w-full object-cover' %>
+  <% if post.image.present? %>
+    <%= image_tag post.image, class: 'h-48 w-full object-cover' %>
+  <% else %>
+    <%= image_tag 'eyecatch.png', class: 'h-48 w-full object-cover' %>
+  <% end %>
+
   <div class="p-4">
     <h2>
       <%= link_to post.cafe_name, post_path(post), class: 'text-brown hover:opacity-70 text-16 font-bold' %>
@@ -17,7 +22,7 @@
           <% end %>
         <% end %>
         <p class="text-14 text-gray-700 font-bold"><%= post.user.profile&.nickname || post.user.display_name %></p>
-      <% end %> 
+      <% end %>
     </div>
     <p class="text-gray-500 text-14">
       <%= post.created_at.strftime("%Y/%m/%d %H:%M") %>


### PR DESCRIPTION
### 概要
投稿画像（`image`）を`commons/_post.html.erb`に表示
***
### 変更内容
- `commons/_post.html.erb`の投稿画像を表示
-  投稿が画像がnill時はデフォルトの画像を表示
***
### 影響
投稿一覧ページとプロフィール詳細の投稿閲覧部分の投稿画像（`image`）の挙動を変更
- 投稿画像作成時：投稿した画像がアイキャッチ画像として表示される
- 投稿画像nill時：デフォルトの画像が表示される
***
### 関連イシュー
#81 投稿画像を該当ビューに表示
***