### PR TITLE
動的OGPの修正4

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -43,7 +43,9 @@
     <% prepare_meta_tags @post %>
    <% post_url = post_url(@post) %>
       <% post_url = post_url(@post) %>
-<% twitter_share_url = "https://twitter.com/share?url=#{CGI.escape("Mycafeを投稿したよ！-#{@post.cafe_name}#{post_url}")}" %>
+<% post_url = post_url(@post) %>
+<% twitter_share_url = "https://twitter.com/share?url=#{CGI.escape("Mycafeを投稿したよ！-#{@post.cafe_name}")}&url=#{post_url}" %>
+
 
     <%= link_to twitter_share_url, target: '_blank', data: { toggle: "tooltip", placement: "bottom" }, title: "Xでシェア" do %>
     <div class="flex items-center mb-8">


### PR DESCRIPTION
動的OGPの共有投稿のカフェ名とURLが結合し、URLがリンクとして機能しなかった為対応