### PR TITLE
プライバシーポリシーの作成

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,4 +1,7 @@
 class StaticPagesController < ApplicationController
   def terms_of_service
   end
+
+  def privacy_policy
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
           <div class="flex space-x-4">
             <%= link_to 'お問い合わせ', '#', class: 'text-brown text-14 font-bold' %>
             <%= link_to '利用規約', terms_of_service_path, class: 'text-brown text-14 font-bold' %>
-            <%= link_to 'プライバシーポリシー', '#', class: 'text-brown text-14 font-bold' %>
+            <%= link_to 'プライバシーポリシー', privacy_policy_path, class: 'text-brown text-14 font-bold' %>
           </div>
         </div>
 

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,0 +1,38 @@
+<body class="bg-cream">
+<div class="container mx-auto px-52 mt-6">
+    <div class="flex justify-center items-center">
+      <%= image_tag 'logo2.png', class: "w-48" %>
+    </div>
+
+    <h1 class="text-3xl font-bold mb-6 text-brown text-center">プライバシーポリシー</h1>
+
+    <h2 class="text-xl text-brown mt-20 mb-10 font-bold">取得する情報</h2>
+    <p class="mb-2 leading-relaxed text-gray-700">当アプリでは、以下の情報をお客様から取得いたします。
+      <ul class="list-disc pl-5 space-y-2 text-gray-700">
+        <li>ニックネーム</li>
+        <li>メールアドレス</li>
+        <li>生年月日</li>
+        <li>MBTI（性格診断結果）</li>
+        <li>居住地（市区町村など、具体的な住所は含みません）</li>
+        <li>Cookie（クッキー）を使用して生成された識別情報</li>
+      </ul>
+    </p>
+
+    <h2 class="text-xl text-brown mt-20 mb-10 font-bold">情報の利用目的</h2>
+    <p class="leading-relaxed text-gray-700 mb-2">取得した情報は、以下の目的で使用いたします。
+      <ul class="list-disc pl-5 space-y-2 text-gray-700">
+        <li>本人確認および認証</li>
+        <li>お問い合わせ対応</li>
+        <li>ユーザー体験を向上させるためのサービス改善および分析</li>
+      </ul>
+    </p>
+
+    <h2 class="text-xl text-brown mt-20 mb-10  font-bold">第三者提供について</h2>
+    <p class="leading-relaxed text-gray-700">お客様の同意なしに、個人情報を第三者に提供することはありません。<br>
+    当アプリは、必要に応じてプライバシーポリシーを改定することがあります。<br>
+    変更がある場合は、適切な方法でお知らせいたします。</p>
+  </div>
+  <div class="flex justify-center items-center mt-24 mb-24">
+    <%= image_tag 'beans.png', class: "w-10" %>
+  </div>
+</body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   get 'images/ogp.png', to: 'images#ogp', as: 'images_ogp'
 
   get 'terms_of_service', to: 'static_pages#terms_of_service'
+  get 'privacy_policy', to: 'static_pages#privacy_policy'
   # Defines the root path route ("/")
   # root "posts#index"
 end


### PR DESCRIPTION
### 概要
プライバシーポリシーの作成
***
### 変更内容
- ルーティング・コントローラ・ビューの作成（`StaticPages/privacy_policy`）
***
### 影響
- 共通フッターのプライバシーポリシーリンクからプライバシーポリシーページを閲覧できる

***
### 関連イシュー
#34  プライバシーポリシー
***