### PR TITLE
ローカル環境で共通ヘッダーにアバター画像が保存されないバグ修正

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -31,6 +31,6 @@ class ProfilesController < ApplicationController
   private
 
   def profile_params
-    params.require(:profile).permit(:nickname, :birthday, :mbti, :address, :introduction, :x_link, :instagram_link, :avatar)
+    params.require(:profile).permit(:nickname, :mbti, :address, :introduction, :x_link, :instagram_link, :avatar)
   end
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,6 @@
 class Profile < ApplicationRecord
    validates :nickname, presence: true, length: { maximum: 50 }
-   validates :mbti, format: { with: /\A[A-Z]{4}\z/, message: 'は4文字のMBTIタイプである必要があります' }, allow_blank: true
+   validates :mbti, format: { with: /\A[A-Z]{4}\z/, message: '英語の大文字4文字（例: INFP, ESTJ）」で入力してくださいgit' }, allow_blank: true
    validates :address, length: { maximum: 100 }, allow_blank: true
    validates :introduction, presence: true, length: { maximum: 500 }
    validates :x_link, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: 'は有効なURLである必要があります' }, allow_blank: true

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,6 +1,5 @@
 class Profile < ApplicationRecord
    validates :nickname, presence: true, length: { maximum: 50 }
-   validates :birthday, presence: true
    validates :mbti, format: { with: /\A[A-Z]{4}\z/, message: 'は4文字のMBTIタイプである必要があります' }, allow_blank: true
    validates :address, length: { maximum: 100 }, allow_blank: true
    validates :introduction, presence: true, length: { maximum: 500 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,8 +29,9 @@
       <% if user_signed_in? %>
         <div class="flex items-center space-x-4">
           <%= link_to image_tag(
-          (current_user.profile&.avatar&.attached? ? url_for(current_user.profile.avatar) : 'profile.png'),
-          class: 'w-12 h-12 rounded-full border-2 shadow-sm'
+            (current_user.profile&.avatar&.persisted? && current_user.profile.avatar.attached?) ?
+            url_for(current_user.profile.avatar) : 'profile.png',
+            class: 'w-12 h-12 rounded-full border-2 shadow-sm'
           ), profile_path %>
           </div>
           <%= link_to image_tag('bookmark.png', class: 'h-11 mt-1'), bookmarks_posts_path %>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
-require_relative "../config/application"
-require "importmap/commands"
+require_relative '../config/application'
+require 'importmap/commands'

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,4 +1,4 @@
 # Pin npm packages by running ./bin/importmap
 
-pin "turbo-rails", to: "turbo.min.js", preload: true
-pin_all_from "app/javascript/controllers", under: "controllers"
+pin 'turbo-rails', to: 'turbo.min.js', preload: true
+pin_all_from 'app/javascript/controllers', under: 'controllers'

--- a/db/migrate/20241012101309_create_profiles.rb
+++ b/db/migrate/20241012101309_create_profiles.rb
@@ -3,7 +3,6 @@ class CreateProfiles < ActiveRecord::Migration[7.2]
     create_table :profiles do |t|
       t.references :user, null: false, foreign_key: true
       t.string :nickname, null: false
-      t.date :birthday, null: false
       t.string :mbti
       t.string :address
       t.text :introduction, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,7 +83,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_16_090340) do
   create_table "profiles", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "nickname", null: false
-    t.date "birthday", null: false
     t.string "mbti"
     t.string "address"
     t.text "introduction", null: false


### PR DESCRIPTION
## 概要
- ローカル環境で共通ヘッダーにアバター画像が保存されないバグ修正
- `profile`テーブルで不要になった`birthday`カラムの削除
- `profile`テーブル・MBTIカラムに対するエラーメッセージの文面を修正

## 変更内容
- `app/views/layouts/application.html.erb`の共通ヘッダーにアバター画像が保存されないバグを修正
-  profilesテーブルのbirthdayカラム削除(テーブルとパラメーターとバリデーション)
- profilesテーブルのMBTIカラムのエラーメッセージを修正（profile.rb）

## 影響
- 共通ヘッダーにアバター画像が保存されるようになる
- MBTIは登録が失敗したときのエラーメッセージがユーザー目線で直感的になる
