### PR TITLE
診断機能追加【カフェデザート】

### DIFF
--- a/app/controllers/desserts_controller.rb
+++ b/app/controllers/desserts_controller.rb
@@ -10,7 +10,7 @@ class DessertsController < ApplicationController
   def result
     # answersがnilの場合は処理を中止してエラーメッセージを表示
     if params[:answers].nil?
-      flash[:error] = "すべての質問に答えてください。"
+      flash[:error] = 'すべての質問に答えてください。'
       redirect_to new_dessert_path
       return
     end

--- a/app/controllers/desserts_controller.rb
+++ b/app/controllers/desserts_controller.rb
@@ -1,0 +1,48 @@
+class DessertsController < ApplicationController
+  def new
+    @questions = [
+      { id: 1, question: '今日の気分に一番近いのは？', options: ['さっぱり', '甘いもの', '温かいもの', '特別なデザート'] },
+      { id: 2, question: '好きな飲み物は？', options: ['緑茶', 'コーヒー', 'ホットミルク', 'フルーツジュース'] },
+      { id: 3, question: 'デザートを食べるシチュエーションは？', options: ['食後', 'カフェタイム', 'おうち', '外出先'] }
+    ]
+  end
+
+  def result
+    # answersがnilの場合は処理を中止してエラーメッセージを表示
+    if params[:answers].nil?
+      flash[:error] = "すべての質問に答えてください。"
+      redirect_to new_dessert_path
+      return
+    end
+
+    answers = params[:answers]
+    answer_counts = {'A' => 0, 'B' => 0, 'C' => 0, 'D' => 0}
+
+    # 回答内容をカウント
+    answers.each do |key, value|
+      case value
+      when 'さっぱり', '緑茶', '食後'
+        answer_counts['A'] += 1
+      when '甘いもの', 'コーヒー', 'カフェタイム'
+        answer_counts['B'] += 1
+      when '温かいもの', 'ホットミルク', 'おうち'
+        answer_counts['C'] += 1
+      when '特別なデザート', 'フルーツジュース', '外出先'
+        answer_counts['D'] += 1
+      end
+    end
+
+    # 結果となるデザートを決定
+    result_dessert = if answer_counts['A'] > answer_counts['B'] && answer_counts['A'] > answer_counts['C']
+      'レアチーズケーキ'
+    elsif answer_counts['B'] > answer_counts['C']
+      'チョコレートケーキ'
+    elsif answer_counts['C'] > answer_counts['D']
+      'アップルパイ'
+    else
+      'フルーツパフェ'
+    end
+
+    @result = result_dessert
+  end
+end

--- a/app/views/desserts/new.html.erb
+++ b/app/views/desserts/new.html.erb
@@ -1,0 +1,21 @@
+<body class="bg-cream">
+  <div class="container mx-auto mt-8 mb-12 px-32 py-6">
+    <h1 class="text-brown text-3xl font-bold mb-8">カフェデザート診断</h1>
+
+    <%= form_with url: result_desserts_path, method: :get, local: true do |f| %>
+      <% @questions.each do |question| %>
+        <div class="mb-8">
+          <h3 class="text-brown"><%= question[:question] %></h3>
+          <% question[:options].each_with_index do |option, index| %>
+            <div>
+              <%= radio_button_tag "answers[#{question[:id]}]", option, false, id: "question_#{question[:id]}_option_#{index}" %>
+              <%= label_tag "question_#{question[:id]}_option_#{index}", option %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <%= f.submit "診断結果を表示", class: "bg-brown text-white px-22 py-3 rounded-md" %>
+    <% end %>
+  </div>
+</body>

--- a/app/views/desserts/result.html.erb
+++ b/app/views/desserts/result.html.erb
@@ -1,0 +1,11 @@
+<body class="bg-cream">
+  <div class="container mx-auto mt-8 mb-20 px-32 py-6">
+    <h1 class="text-brown text-3xl font-bold mb-20">カフェデザートの診断結果</h1>
+
+    <p class="mb-20 text-2xl">あなたにおすすめのカフェデザートは：<%= @result %></p>
+
+
+    <%= link_to 'もう一度診断する', new_dessert_path, class: 'bg-brown text-white px-2 py-3 rounded-md' %>
+    <%= link_to '診断一覧ページに戻る', diagnoses_path, class: 'bg-brown text-white px-2 py-3 rounded-md' %>
+  </div>
+</body>

--- a/app/views/diagnoses/index.html.erb
+++ b/app/views/diagnoses/index.html.erb
@@ -6,7 +6,7 @@
     <div class="space-y-4">
       <%= link_to 'カフェドリンク 診断する', '#', class: 'block px-4 py-8 bg-teal text-white font-bold  rounded-md text-center hover:opacity-70' %>
       <%= link_to 'コーヒー豆 診断する', new_coffee_bean_path, class: 'block px-4 py-8 bg-teal text-white font-bold  rounded-md text-center hover:opacity-70' %>
-      <%= link_to 'カフェデザート 診断する', '#', class: 'block px-4 py-8 bg-teal text-white font-bold rounded-md text-center hover:opacity-70' %>
+      <%= link_to 'カフェデザート 診断する', new_dessert_path, class: 'block px-4 py-8 bg-teal text-white font-bold rounded-md text-center hover:opacity-70' %>
     </div>
 
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,12 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :desserts, only: [:new] do
+    collection do
+      get :result
+    end
+  end
+
   get 'terms_of_service', to: 'static_pages#terms_of_service'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'contact', to: redirect('https://forms.gle/z8sibaa5aQfKe9os8')


### PR DESCRIPTION
## 概要
診断一覧ページから遷移できる診断機能【カフェデザート】を追加。

## 変更内容
- 診断一覧ページからカフェデザート診断に飛べるようにpathの追加
- ルーティング・コントローラ（診断のアルゴリズム）・ビュー（カフェデザート診断ページ・カフェデザート診断結果ページ）を作成