### PR TITLE
診断機能追加【カフェドリンク】

### DIFF
--- a/app/controllers/drinks_controller.rb
+++ b/app/controllers/drinks_controller.rb
@@ -1,0 +1,46 @@
+class DrinksController < ApplicationController
+  def new
+    @questions = [
+      { id: 1, question: '朝起きた時の気分は？', options: ['すっきり目覚めたい！', 'ゆっくり始めたい気分', 'パワフルに活動したい', 'リラックスして一日を始めたい'] },
+      { id: 2, question: 'お気に入りのスナックは？', options: ['抹茶を使ったスイーツ', 'ヘルシーなナッツやドライフルーツ', 'チョコレートやクッキー', '和菓子や煎餅'] },
+      { id: 3, question: '理想のカフェタイムはどんなシチュエーション？', options: ['本を読みながら静かに過ごす', '健康志向のランチを楽しむ', '友達とおしゃべりしながら楽しく過ごす', '自然光の差し込むカフェでリラックスする'] }
+    ]
+  end
+
+  def result
+    if params[:answers].nil?
+      flash[:error] = 'すべての質問に答えてください。'
+      redirect_to new_drink_path
+      return
+    end
+
+    answers = params[:answers]
+    answer_counts = {'A' => 0, 'B' => 0, 'C' => 0, 'D' => 0}
+
+    # 回答内容をカウント
+    answers.each do |key, value|
+      case value
+      when 'すっきり目覚めたい！', '抹茶を使ったスイーツ', '本を読みながら静かに過ごす'
+        answer_counts['A'] += 1
+      when 'ゆっくり始めたい気分', 'ヘルシーなナッツやドライフルーツ', '健康志向のランチを楽しむ'
+        answer_counts['B'] += 1
+      when 'パワフルに活動したい', 'チョコレートやクッキー', '友達とおしゃべりしながら楽しく過ごす'
+        answer_counts['C'] += 1
+      when 'リラックスして一日を始めたい', '和菓子や煎餅', '自然光の差し込むカフェでリラックスする'
+        answer_counts['D'] += 1
+      end
+    end
+
+    result_cafe_time = if answer_counts['A'] > answer_counts['B'] && answer_counts['A'] > answer_counts['C']
+      '抹茶系がおすすめ！'
+    elsif answer_counts['B'] > answer_counts['C']
+      'ソイ系がおすすめ！'
+    elsif answer_counts['C'] > answer_counts['D']
+      'カフェラテがおすすめ！'
+    else
+      'ほうじ茶系がおすすめ！'
+    end
+
+    @result = result_cafe_time
+  end
+end

--- a/app/views/diagnoses/index.html.erb
+++ b/app/views/diagnoses/index.html.erb
@@ -4,7 +4,7 @@
     <h1 class="text-center text-brown text-3xl font-bold mb-8">診断する</h1>
 
     <div class="space-y-4">
-      <%= link_to 'カフェドリンク 診断する', '#', class: 'block px-4 py-8 bg-teal text-white font-bold  rounded-md text-center hover:opacity-70' %>
+      <%= link_to 'カフェドリンク 診断する', new_drink_path, class: 'block px-4 py-8 bg-teal text-white font-bold  rounded-md text-center hover:opacity-70' %>
       <%= link_to 'コーヒー豆 診断する', new_coffee_bean_path, class: 'block px-4 py-8 bg-teal text-white font-bold  rounded-md text-center hover:opacity-70' %>
       <%= link_to 'カフェデザート 診断する', new_dessert_path, class: 'block px-4 py-8 bg-teal text-white font-bold rounded-md text-center hover:opacity-70' %>
     </div>

--- a/app/views/drinks/new.html.erb
+++ b/app/views/drinks/new.html.erb
@@ -1,0 +1,21 @@
+<body class="bg-cream">
+  <div class="container mx-auto mt-8 mb-12 px-32 py-6">
+    <h1 class="text-brown text-3xl font-bold mb-8">カフェドリンク診断</h1>
+
+    <%= form_with url: result_drinks_path, method: :get, local: true do |f| %>
+      <% @questions.each do |question| %>
+        <div class="mb-8">
+          <h3 class="text-brown"><%= question[:question] %></h3>
+          <% question[:options].each_with_index do |option, index| %>
+            <div>
+              <%= radio_button_tag "answers[#{question[:id]}]", option, false, id: "question_#{question[:id]}_option_#{index}" %>
+              <%= label_tag "question_#{question[:id]}_option_#{index}", option %>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+
+      <%= f.submit "診断結果を見る", class: "bg-brown text-white px-22 py-3 rounded-md" %>
+    <% end %>
+  </div>
+</body>

--- a/app/views/drinks/result.html.erb
+++ b/app/views/drinks/result.html.erb
@@ -1,0 +1,11 @@
+<body class="bg-cream">
+  <div class="container mx-auto mt-8 mb-20 px-32 py-6">
+    <h1 class="text-brown text-3xl font-bold mb-20">カフェドリンク診断結果</h1>
+
+    <p class="mb-20 text-2xl">あなたにおすすめのカフェドリンクは：<%= @result %></p>
+
+
+    <%= link_to 'もう一度診断する', new_drink_path, class: 'bg-brown text-white px-2 py-3 rounded-md' %>
+    <%= link_to '診断一覧ページに戻る', diagnoses_path, class: 'bg-brown text-white px-2 py-3 rounded-md' %>
+  </div>
+</body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,8 +58,6 @@ Rails.application.routes.draw do
       get :result
     end
   end
-
-
   get 'terms_of_service', to: 'static_pages#terms_of_service'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'contact', to: redirect('https://forms.gle/z8sibaa5aQfKe9os8')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,13 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :drinks, only: [:new] do
+    collection do
+      get :result
+    end
+  end
+
+
   get 'terms_of_service', to: 'static_pages#terms_of_service'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'contact', to: redirect('https://forms.gle/z8sibaa5aQfKe9os8')


### PR DESCRIPTION
## 概要
診断一覧ページから遷移できる診断機能【カフェドリンク】を追加。

## 変更内容
- 診断一覧ページからカフェドリンク診断に飛べるようにpathの追加
- ルーティング・コントローラ（診断のアルゴリズム）・ビュー（カフェドリンク診断ページ・カフェドリンク診断結果ページ）を作成