### PR TITLE
オートコンプリート機能の導入

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,4 +1,5 @@
 // app/assets/javascripts/application.js
 //= require_tree .
 //= require_self
+//= require autocomplete
 //# sourceMappingURL=application.js.map

--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -1,0 +1,46 @@
+document.addEventListener("DOMContentLoaded", function() {
+  const searchInput = document.getElementById("search-input");
+  const resultsList = document.getElementById("autocomplete-results");
+
+  searchInput.addEventListener("input", function() {
+    const query = searchInput.value;
+
+    // 入力が2文字以上の場合のみ検索
+    if (query.length > 1) {
+      fetch(`/posts/autocomplete?query=${query}`)
+        .then(response => response.json())
+        .then(data => {
+          console.log(data); // 取得したデータをログで確認
+          resultsList.innerHTML = ""; // 検索結果をリセット
+
+          if (data.length > 0) {
+            resultsList.classList.remove("hidden"); // 結果を表示
+            data.forEach(cafeName => {
+              const listItem = document.createElement("li");
+              listItem.classList.add("p-2", "cursor-pointer");
+              listItem.textContent = cafeName;
+              listItem.addEventListener("click", function() {
+                searchInput.value = cafeName;
+                resultsList.classList.add("hidden"); // 結果を非表示にする
+              });
+              resultsList.appendChild(listItem);
+            });
+          } else {
+            resultsList.classList.add("hidden"); // 結果がない場合非表示
+          }
+        })
+        .catch(error => {
+          console.error("Error fetching autocomplete data:", error);
+          resultsList.classList.add("hidden"); // エラー時に非表示
+        });
+    } else {
+      resultsList.classList.add("hidden"); // 入力が少ない場合は非表示
+    }
+  });
+
+  document.addEventListener("click", function(event) {
+    if (!resultsList.contains(event.target) && event.target !== searchInput) {
+      resultsList.classList.add("hidden"); // 他の場所をクリックした場合に非表示
+    }
+  });
+});

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,6 +58,15 @@ class PostsController < ApplicationController
     @bookmark_posts = current_user.bookmarks.includes(:post).map(&:post)
   end
 
+  def autocomplete
+    if params[:query].present?
+      @posts = Post.where('cafe_name LIKE ?', "%#{params[:query]}%").limit(10)
+      render json: @posts.map(&:cafe_name)
+    else
+      render json: []
+    end
+  end
+
   private
   def post_params
     params.require(:post).permit(:cafe_name, :body, :address, :cafe_link, :image, :latitude, :longitude, tag_ids: [])

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,10 +5,15 @@
       <i class="fa fa-plus text-brown text-2xl"></i>
       <span class="text-brown text-xl font-bold ml-2">投稿する</span>
     <% end %>
-    <%= search_form_for @q, class: 'd-flex mb-3' do |f| %>
-        <%= f.search_field :cafe_name_or_body_or_address_cont, class: 'mt-2 rounded-md p-1 text-brown me-2 text-sm', placeholder: '検索キーワードを入力' %>
-        <%= f.submit '検索', class: 'bg-brown text-white p-1 pl-2 pr-2 rounded-md' %>
-      <% end %>
+    <%= search_form_for @q, url: posts_path, method: :get, class: 'd-flex relative' do |f| %>
+      <%= f.search_field :cafe_name_cont, id: "search-input", class: "form-control me-2", placeholder: "カフェ名を入力", autocomplete: "off" %>
+      <button class="btn btn-outline-success" type="submit">検索</button>
+    <% end %>
+
+    <ul id="autocomplete-results" class="absolute mt-1 max-h-60 overflow-y-auto bg-white shadow-lg rounded border w-full hidden">
+    </ul>
+  <script src="/assets/autocomplete.js"></script>
+
 
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">
       <% @posts.each do |post| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
     resources :comments, only: [:new, :create, :edit, :update, :destroy]
       collection do
         get :bookmarks
+        get :autocomplete
       end
   end
 


### PR DESCRIPTION
## 概要
- ransackを用いた検索機能にオートコンプリート機能の追加
（`posts`テーブルの`cafe_name`カラム）

## 変更内容
-  ルーティングに`autocomplete`エンドポイントを追加 (`config/routes.rb`)
- 投稿一覧画面で、オートコンプリート検索フォームを設定(`app/views/posts/index.html.erb`)
- 検索クエリに基づいたカフェ名の候補を返すコードを記述(`app/controllers/posts_controller.rb`)
- 検索ボックスにオートコンプリート機能を追加（`app/assets/javascripts/autocomplete.js`）

## 備考
- デザイン（tailwindCSS）の追加は今後実装予定