### PR TITLE
本番環境でオートコンプリート機能が反映されないエラーを修正

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -12,7 +12,7 @@
 
     <ul id="autocomplete-results" class="absolute mt-1 max-h-60 overflow-y-auto bg-white shadow-lg rounded border w-full hidden">
     </ul>
-  <script src="/assets/autocomplete.js"></script>
+    <script src="/assets/autocomplete.js"></script>
 
 
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fall back to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,3 @@ Rails.application.config.assets.version = '1.0'
 # folder are already added.
 # Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
 Rails.application.config.assets.precompile += %w( application.js autocomplete.js )
-

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,4 +10,5 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 # Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
-Rails.application.config.assets.precompile += %w( application.js )
+Rails.application.config.assets.precompile += %w( application.js autocomplete.js )
+


### PR DESCRIPTION
## 概要
本番環境でオートコンプリート機能が反映されないエラーを修正

エラー内容
```
リクエスト URL:
https://magco.onrender.com/assets/autocomplete.js
リクエスト メソッド:
GET
ステータス コード:
404 Not Found
```

## 変更内容
- 本番環境でアセットを動的にコンパイル することを許可する設定を追加 (
`config/environments/production.rb`)
- `autocomplete.js` をプリコンパイル対象に許可（`config/initializers/assets.rb`）