### PR TITLE
住所の都道府県別検索機能とタグ別検索機能の追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,10 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:user).order(created_at: :desc)
+    @posts = @q.result(distinct: true).includes(:user, :tags).order(created_at: :desc)
+
+    @prefectures = Post::PREFECTURES
+    @tags = Tag.all
   end
 
   def show

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,12 +14,22 @@ class Post < ApplicationRecord
   geocoded_by :address
   after_validation :geocode, if: :address_changed?
 
+  PREFECTURES = [
+    '北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県',
+    '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県',
+    '新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県', '岐阜県',
+    '静岡県', '愛知県', '三重県', '滋賀県', '京都府', '大阪府', '兵庫県',
+    '奈良県', '和歌山県', '鳥取県', '島根県', '岡山県', '広島県', '山口県',
+    '徳島県', '香川県', '愛媛県', '高知県', '福岡県', '佐賀県', '長崎県',
+    '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'
+  ]
+
   def self.ransackable_attributes(auth_object = nil)
     %w[cafe_name body address]
   end
 
   def self.ransackable_associations(auth_object = nil)
-    []
+    ['tags']
   end
 
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,3 +1,7 @@
 class Tag < ApplicationRecord
   has_and_belongs_to_many :posts
+
+  def self.ransackable_attributes(auth_object = nil)
+    ['name']
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,16 +1,35 @@
 <% content_for(:title, t('.title')) %>
 <div class="bg-cream">
   <div class="container mx-auto pt-10">
-<%= search_form_for @q, url: posts_path, method: :get, class: 'flex flex-wrap items-center mt-1 space-y-2 sm:space-y-0 sm:space-x-2' do |f| %>
+<%= search_form_for @q, url: posts_path, method: :get, class: 'flex flex-col sm:flex-row gap-2 items-start sm:items-center' do |f| %>
+  <!-- 検索ボックス -->
   <%= f.search_field :cafe_name_cont, id: "search-input",
-    class: "w-full sm:w-auto flex-1 px-4 py-2 border border-brown rounded text-brown placeholder:text-brown focus:outline-none focus:ring-2 focus:ring-brown",
+    class: "w-full sm:flex-1 px-4 py-2 border border-brown rounded-lg text-brown placeholder:text-brown focus:outline-none focus:ring-2 focus:ring-brown",
     placeholder: "カフェ名を入力",
     autocomplete: "off" %>
+
+  <!-- フィルター用の選択肢 -->
+  <div class="flex w-full sm:w-auto gap-2">
+    <div class="flex-1 sm:flex-none sm:w-44 md:w-48">
+      <%= f.select :address_cont,
+        @prefectures,
+        { include_blank: "都道府県を選択" },
+        class: "w-full px-4 py-2 border border-brown rounded-lg text-brown bg-white focus:outline-none focus:ring-2 focus:ring-brown focus:border-brown" %>
+    </div>
+
+    <div class="flex-1 sm:flex-none sm:w-44 md:w-48">
+      <%= f.select :tags_name_eq,
+        @tags.pluck(:name),
+        { include_blank: 'タグを選択' },
+        class: "w-full px-4 py-2 border border-brown rounded-lg text-brown bg-white focus:outline-none focus:ring-2 focus:ring-brown focus:border-brown" %>
+    </div>
+  </div>
+
+  <!-- 検索ボタン -->
   <button id="search-button" class="w-full sm:w-auto px-4 py-2 bg-brown text-white rounded border border-brown hover:bg-opacity-90 transition duration-300 flex items-center justify-center">
     <i class="fa-solid fa-magnifying-glass"></i>
   </button>
 <% end %>
-
 
     <ul id="autocomplete-results" class="absolute mt-1 max-h-60 bg-cream text-brown shadow-lg rounded border w-full hidden">
     </ul>

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -128,8 +128,8 @@ RSpec.describe Post, type: :model do
       expect(Post.ransackable_attributes).to match_array(%w[cafe_name body address])
     end
 
-    it 'ransackable_associations が空配列を返す' do
-      expect(Post.ransackable_associations).to eq([])
+    it "ransackable_associations がタグ関連付けのみを返す" do
+      expect(Post.ransackable_associations).to eq(%w[tags])
     end
   end
 end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Post, type: :model do
       expect(Post.ransackable_attributes).to match_array(%w[cafe_name body address])
     end
 
-    it "ransackable_associations がタグ関連付けのみを返す" do
+    it 'ransackable_associations がタグ関連付けのみを返す' do
       expect(Post.ransackable_associations).to eq(%w[tags])
     end
   end


### PR DESCRIPTION
## 概要
検索機能を充実させるために都道府県別とタグ別の検索機能を追加しました。

## 変更内容
- 都道府県の定数 とタグをコントローラーで取得(`app/controllers/posts_controller.rb`)
- 都道府県のデータを追加(`app/models/post.rb`)
- `ransackable_associations` メソッドで tags アソシエーションを検索対象として追加し、Tag モデルに `ransackable_attributes`メソッドを定義して name 属性を検索可能に(`app/models/post.rb`・`app/models/tag.rb`)
- 都道府県別とタグ別の検索機能のビュー作成(`app/views/posts/index.html.erb`)