### PR TITLE
ログイン・新規登録後のリダイレクト先を変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,11 @@
 class ApplicationController < ActionController::Base
   allow_browser versions: :modern
 
-  def after_sign_out_path_for(resource_or_scope)
-    new_user_session_path
+  def after_sign_in_path_for(resource)
+    root_path
+  end
+
+  def after_sign_up_path_for(resource)
+    root_path
   end
 end


### PR DESCRIPTION
## 概要
ログイン・新規登録後のリダイレクト先をTOPページ(`rootpath`)に変更しました。

## 変更内容
- ログイン・新規登録後のリダイレクト先をTOPページ(`rootpath`)に変更(`app/controllers/application_controller.rb`)