### PR TITLE
ブックマーク一覧ページとタグ詳細ページに検索機能を追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -58,10 +58,10 @@ class PostsController < ApplicationController
   end
 
   def bookmarks
-    @bookmark_posts = current_user.bookmark_posts
-                               .order(created_at: :desc)
-                               .page(params[:page])
-                               .per(8)
+    @q = current_user.bookmark_posts.ransack(params[:q])
+    @bookmark_posts = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(8)
+    @prefectures = Post::PREFECTURES
+    @tags = Tag.all
   end
 
   def autocomplete

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,6 +1,9 @@
 class TagsController < ApplicationController
   def show
-    @tag = Tag.find(params[:id])  # IDでタグを検索
-    @posts = @tag.posts.page(params[:page]).per(8)
+    @tag = Tag.find(params[:id])
+    @q = @tag.posts.ransack(params[:q])
+    @posts = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(8)
+    @prefectures = Post::PREFECTURES
+    @tags = Tag.all
   end
 end

--- a/app/views/commons/_search_form.html.erb
+++ b/app/views/commons/_search_form.html.erb
@@ -1,0 +1,34 @@
+<%= search_form_for @q, url: search_url, method: :get, class: 'flex flex-col sm:flex-row gap-2 items-start sm:items-center' do |f| %>
+
+  <!-- 検索ボックス -->
+  <%= f.search_field :cafe_name_cont, id: "search-input",
+    class: "w-full sm:flex-1 px-4 py-2 border border-brown rounded-lg text-brown placeholder:text-brown focus:outline-none focus:ring-2 focus:ring-brown",
+    placeholder: "カフェ名を入力",
+    autocomplete: "off" %>
+
+  <!-- フィルター用の選択肢 -->
+  <div class="flex w-full sm:w-auto gap-2">
+    <div class="flex-1 sm:flex-none sm:w-44 md:w-48">
+      <%= f.select :address_cont,
+        @prefectures,
+        { include_blank: "都道府県を選択" },
+        class: "w-full px-4 py-2 border border-brown rounded-lg text-brown bg-white focus:outline-none focus:ring-2 focus:ring-brown focus:border-brown" %>
+    </div>
+
+    <div class="flex-1 sm:flex-none sm:w-44 md:w-48">
+      <%= f.select :tags_name_eq,
+        @tags.pluck(:name),
+        { include_blank: 'タグを選択' },
+        class: "w-full px-4 py-2 border border-brown rounded-lg text-brown bg-white focus:outline-none focus:ring-2 focus:ring-brown focus:border-brown" %>
+    </div>
+  </div>
+
+  <!-- 検索ボタン -->
+  <button id="search-button" class="w-full sm:w-auto px-4 py-2 bg-brown text-white rounded border border-brown hover:bg-opacity-90 transition duration-300 flex items-center justify-center">
+    <i class="fa-solid fa-magnifying-glass"></i>
+  </button>
+<% end %>
+
+    <ul id="autocomplete-results" class="absolute mt-1 max-h-60 bg-cream text-brown shadow-lg rounded border w-full hidden">
+    </ul>
+    <script src="/assets/autocomplete.js"></script>

--- a/app/views/commons/_search_form_tags.html.erb
+++ b/app/views/commons/_search_form_tags.html.erb
@@ -1,0 +1,27 @@
+<%= search_form_for @q, url: search_url, method: :get, class: 'flex flex-col sm:flex-row gap-2 items-start sm:items-center' do |f| %>
+
+  <!-- 検索ボックス -->
+  <%= f.search_field :cafe_name_cont, id: "search-input",
+    class: "w-full sm:flex-1 px-4 py-2 border border-brown rounded-lg text-brown placeholder:text-brown focus:outline-none focus:ring-2 focus:ring-brown",
+    placeholder: "カフェ名を入力",
+    autocomplete: "off" %>
+
+  <!-- フィルター用の選択肢 -->
+  <div class="flex w-full sm:w-auto gap-2">
+    <div class="flex-1 sm:flex-none sm:w-44 md:w-48">
+      <%= f.select :address_cont,
+        @prefectures,
+        { include_blank: "都道府県を選択" },
+        class: "w-full px-4 py-2 border border-brown rounded-lg text-brown bg-white focus:outline-none focus:ring-2 focus:ring-brown focus:border-brown" %>
+    </div>
+  </div>
+
+  <!-- 検索ボタン -->
+  <button id="search-button" class="w-full sm:w-auto px-4 py-2 bg-brown text-white rounded border border-brown hover:bg-opacity-90 transition duration-300 flex items-center justify-center">
+    <i class="fa-solid fa-magnifying-glass"></i>
+  </button>
+<% end %>
+
+    <ul id="autocomplete-results" class="absolute mt-1 max-h-60 bg-cream text-brown shadow-lg rounded border w-full hidden">
+    </ul>
+    <script src="/assets/autocomplete.js"></script>

--- a/app/views/posts/bookmarks.html.erb
+++ b/app/views/posts/bookmarks.html.erb
@@ -2,10 +2,13 @@
 <% content_for(:title, t('.title')) %>
 <body class="bg-cream">
   <div class="container mx-auto">
-    <div class="text-3xl text-brown font-bold mt-8">
+    <div class="text-3xl text-brown font-bold mt-8 mb-4">
       <i class="fa-solid fa-bookmark fa-sm text-brown mr-2"></i>
       ブックマーク一覧
     </div>
+
+    <%= render 'commons/search_form', search_url: bookmarks_posts_path %>
+
     <% if @bookmark_posts.present? %>
       <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 pt-6 pb-8">
         <% @bookmark_posts.each do |post| %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,50 +1,16 @@
 <% content_for(:title, t('.title')) %>
 <div class="bg-cream">
   <div class="container mx-auto pt-10">
-<%= search_form_for @q, url: posts_path, method: :get, class: 'flex flex-col sm:flex-row gap-2 items-start sm:items-center' do |f| %>
-  <!-- 検索ボックス -->
-  <%= f.search_field :cafe_name_cont, id: "search-input",
-    class: "w-full sm:flex-1 px-4 py-2 border border-brown rounded-lg text-brown placeholder:text-brown focus:outline-none focus:ring-2 focus:ring-brown",
-    placeholder: "カフェ名を入力",
-    autocomplete: "off" %>
 
-  <!-- フィルター用の選択肢 -->
-  <div class="flex w-full sm:w-auto gap-2">
-    <div class="flex-1 sm:flex-none sm:w-44 md:w-48">
-      <%= f.select :address_cont,
-        @prefectures,
-        { include_blank: "都道府県を選択" },
-        class: "w-full px-4 py-2 border border-brown rounded-lg text-brown bg-white focus:outline-none focus:ring-2 focus:ring-brown focus:border-brown" %>
-    </div>
+  <%= render 'commons/search_form', search_url: posts_path %>
 
-    <div class="flex-1 sm:flex-none sm:w-44 md:w-48">
-      <%= f.select :tags_name_eq,
-        @tags.pluck(:name),
-        { include_blank: 'タグを選択' },
-        class: "w-full px-4 py-2 border border-brown rounded-lg text-brown bg-white focus:outline-none focus:ring-2 focus:ring-brown focus:border-brown" %>
-    </div>
+  <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">
+    <% @posts.each do |post| %>
+        <%= render 'commons/post', post: post %>
+    <% end %>
   </div>
 
-  <!-- 検索ボタン -->
-  <button id="search-button" class="w-full sm:w-auto px-4 py-2 bg-brown text-white rounded border border-brown hover:bg-opacity-90 transition duration-300 flex items-center justify-center">
-    <i class="fa-solid fa-magnifying-glass"></i>
-  </button>
-<% end %>
-
-    <ul id="autocomplete-results" class="absolute mt-1 max-h-60 bg-cream text-brown shadow-lg rounded border w-full hidden">
-    </ul>
-    <script src="/assets/autocomplete.js"></script>
-
-
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">
-      <% @posts.each do |post| %>
-          <%= render 'commons/post', post: post %>
-      <% end %>
-    </div>
-
-
-      <%= paginate @posts %>
-
+  <%= paginate @posts %>
 
   <%= link_to new_post_path do %>
     <div class="bg-teal border-4 border-white p-4 rounded-full shadow-lg fixed bottom-2 right-2 flex items-center justify-center w-16 h-16 hover:opacity-70">

--- a/app/views/tags/show.html.erb
+++ b/app/views/tags/show.html.erb
@@ -1,7 +1,11 @@
 <% content_for(:title, @tag.name) %>
 <div class="bg-cream">
   <div class="container mx-auto pt-10">
+
   <h1 class="text-2xl font-bold mb-3"><i class="text-brown fa-solid fa-hashtag"></i><span class="text-brown"><%= @tag.name %></span> <span class="text-gray-700 text-xl">に関連する投稿</span></h1>
+
+   <%= render 'commons/search_form_tags', search_url: tag_path(@tag) %>
+
     <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">
       <% @posts.each do |post| %>
       <%= render 'commons/post', post: post %>


### PR DESCRIPTION
## 概要
ブックマーク一覧ページとタグ詳細ページに検索機能を追加
検索機能のコードをパーシャル化

## 変更内容
- 検索機能のコードをパーシャル化(`app/views/commons/_search_form.html.erb`・`app/views/commons/_search_form_tags.html.erb`・`app/views/posts/index.html.erb`)
- ブックマーク一覧ページに検索機能を追加(`app/views/posts/bookmarks.html.erb`・`app/controllers/posts_controller.rb`)
- 詳細ページに検索機能を追加(`app/views/tags/show.html.erb`・`app/controllers/tags_controller.rb`)