### PR TITLE
AIカフェ診断ページ 動的タイトルの追加

### DIFF
--- a/app/views/daily_advices/index.html.erb
+++ b/app/views/daily_advices/index.html.erb
@@ -1,7 +1,8 @@
+<% content_for(:title, t('.title')) %>
 <div class="container mx-auto px-6 py-8">
   <div class="max-w-2xl mx-auto">
     <h1 class="text-2xl font-bold text-brown mb-4">
-      <i class="fas fa-coffee mr-2"></i>
+      <i class="fas fa-acoffee mr-2"></i>
       Cafe AI
     </h1>
 

--- a/app/views/daily_advices/index.html.erb
+++ b/app/views/daily_advices/index.html.erb
@@ -2,7 +2,7 @@
 <div class="container mx-auto px-6 py-8">
   <div class="max-w-2xl mx-auto">
     <h1 class="text-2xl font-bold text-brown mb-4">
-      <i class="fas fa-acoffee mr-2"></i>
+      <i class="fas fa-coffee mr-2"></i>
       Cafe AI
     </h1>
 

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -48,6 +48,9 @@ ja:
       title: "カフェドリンク診断"
     result:
       title: "カフェドリンク診断：結果"
+  daily_advices:
+    index:
+      title: "AIカフェ診断"
   pagination:
     previous: "前へ"
     next: "次へ"


### PR DESCRIPTION
## 概要
AIカフェ診断ページの動的タイトル追加をしました。
```
Magco | AIカフェ診断
```

## 変更内容
- 動的タイトルの追加(`app/views/daily_advices/index.html.erb`・`config/locales/views/ja.yml`)