### PR TITLE
fix:オートコンプリートの仕様修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -66,7 +66,7 @@ class PostsController < ApplicationController
 
   def autocomplete
     if params[:query].present?
-      @posts = Post.where('cafe_name LIKE ?', "%#{params[:query]}%").limit(10)
+      @posts = Post.where('cafe_name ILIKE ?', "%#{params[:query]}%")
       render json: @posts.map(&:cafe_name)
     else
       render json: []

--- a/app/views/commons/_search_form.html.erb
+++ b/app/views/commons/_search_form.html.erb
@@ -7,7 +7,7 @@
       placeholder: "カフェ名を入力",
       autocomplete: "off" %>
 
-      <ul id="autocomplete-results" class="absolute fixed left-0 max-h-60 bg-cream text-brown shadow-lg rounded border w-full hidden ml-2">
+      <ul id="autocomplete-results" class="absolute fixed left-0 max-h-60 bg-cream text-brown shadow-lg rounded border w-full hidden max-h-[150px] overflow-y-auto">
       </ul>
     </div>
 

--- a/app/views/commons/_search_form_tags.html.erb
+++ b/app/views/commons/_search_form_tags.html.erb
@@ -7,7 +7,7 @@
       placeholder: "カフェ名を入力",
       autocomplete: "off" %>
 
-  <ul id="autocomplete-results" class="absolute top-full left-0 max-h-60 bg-cream text-brown shadow-lg rounded border w-full z-0 overflow-auto">
+  <ul id="autocomplete-results" class="absolute fixed left-0 max-h-60 bg-cream text-brown shadow-lg rounded border w-full hidden max-h-[150px] overflow-y-auto">
   </ul>
 </div>
 


### PR DESCRIPTION
## 概要
オートコンプリートの仕様を修正しました。
- 英語検索の場合、小文字・大文字が一致していなくてもオートコンプリートが表示されるようにしました。
- オートコンプリートの表示数を無条件にしました。
- オートコンプリートの高さが150px以上表示される時に自動でスクロールバーを表示されるようにしました。

## 変更内容
- 英語検索の場合、小文字・大文字が一致していなくてもオートコンプリートが表示される・オートコンプリートの表示数を無条件(`app/controllers/posts_controller.rb`)
- オートコンプリートの高さが150px以上表示される時に自動でスクロールバーを表示(`app/views/commons/_search_form.html.erb`・`app/views/commons/_search_form_tags.html.erb`)