### PR TITLE
共通ヘッダーのナビゲーション部分のコンポーネント作成・導入

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,61 +5,9 @@
     </div>
     <div class="flex items-center space-x-4">
       <% if user_signed_in? %>
-        <div class="navbar text-brown font-bold z-50 relative">
-          <div class="navbar-start">
-            <div class="dropdown">
-              <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  class="h-8 w-8"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  stroke="currentColor">
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M4 6h16M4 12h16M4 18h7" />
-                </svg>
-              </div>
-              <ul
-                tabindex="0"
-                class="menu menu-sm dropdown-content bg-base-100 rounded-box mt-3 w-52 p-2 shadow right-0 font-bold z-50">
-                <li><%= link_to 'マイページ', profile_path %></li>
-                <li><%= link_to '投稿する', new_post_path %></li>
-                <li><%= link_to 'ブックマーク一覧', bookmarks_posts_path %></li>
-                <li><%= link_to 'カフェ診断', diagnoses_path %></li>
-                <li><%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete } %></li>
-              </ul>
-            </div>
-          </div>
-        </div>
+        <%= render 'shared/signed_in_navbar' %>
       <% else %>
-        <div class="navbar-start">
-          <div class="dropdown">
-            <div tabindex="0" role="button" class="btn btn-ghost btn-circle text-brown">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                class="h-8 w-8"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor">
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="2"
-                  d="M4 6h16M4 12h16M4 18h7" />
-              </svg>
-            </div>
-            <ul
-              tabindex="0"
-              class="menu menu-sm dropdown-content bg-base-100 rounded-box mt-3 w-52 p-2 shadow right-0 text-brown font-bold z-50">
-              <li><%= link_to 'ログイン', new_user_session_path %></li>
-              <li><%= link_to '新規登録', new_user_registration_path %></li>
-              <li><%= link_to 'リセットパスワード', new_user_password_path %></li>
-            </ul>
-          </div>
-        </div>
+        <%= render 'shared/signed_out_navbar' %>
       <% end %>
     </div>
   </header>

--- a/app/views/shared/_signed_in_navbar.html.erb
+++ b/app/views/shared/_signed_in_navbar.html.erb
@@ -1,0 +1,29 @@
+<div class="navbar text-brown font-bold z-50 relative">
+  <div class="navbar-start">
+    <div class="dropdown">
+      <div tabindex="0" role="button" class="btn btn-ghost btn-circle">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          class="h-8 w-8"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M4 6h16M4 12h16M4 18h7" />
+        </svg>
+      </div>
+      <ul
+        tabindex="0"
+        class="menu menu-sm dropdown-content bg-base-100 rounded-box mt-3 w-52 p-2 shadow right-0 font-bold z-50">
+        <li><%= link_to 'マイページ', profile_path %></li>
+        <li><%= link_to '投稿する', new_post_path %></li>
+        <li><%= link_to 'ブックマーク一覧', bookmarks_posts_path %></li>
+        <li><%= link_to 'カフェ診断', diagnoses_path %></li>
+        <li><%= button_to 'ログアウト', destroy_user_session_path, method: :delete, data: { turbo_method: :delete } %></li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_signed_out_navbar.html.erb
+++ b/app/views/shared/_signed_out_navbar.html.erb
@@ -1,0 +1,25 @@
+<div class="navbar-start">
+  <div class="dropdown">
+    <div tabindex="0" role="button" class="btn btn-ghost btn-circle text-brown">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-8 w-8"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor">
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h7" />
+      </svg>
+    </div>
+    <ul
+      tabindex="0"
+      class="menu menu-sm dropdown-content bg-base-100 rounded-box mt-3 w-52 p-2 shadow right-0 text-brown font-bold z-50">
+      <li><%= link_to 'ログイン', new_user_session_path %></li>
+      <li><%= link_to '新規登録', new_user_registration_path %></li>
+      <li><%= link_to 'リセットパスワード', new_user_password_path %></li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
## 概要
共通ヘッダーのナビゲーション部分のコンポーネント作成をしました。
上記のコンポーネント化は `if user_signed_in?`でログイン時とログアウト時で分けています。

## 変更内容
- サインインした時のナビゲーションのコンポーネントを作成(`app/views/shared/_signed_in_navbar.html.erb`)
- サインアウトした時のナビゲーションのコンポーネントを作成(`app/views/shared/_signed_out_navbar.html.erb`)
- 共通ヘッダーのナビゲーション部分のコンポーネント化(`app/views/shared/_header.html.erb`)