### PR TITLE
診断フォームのコンポーネント作成・導入

### DIFF
--- a/app/views/coffee_beans/new.html.erb
+++ b/app/views/coffee_beans/new.html.erb
@@ -7,21 +7,7 @@
     </h1>
 
     <%= form_with url: result_coffee_beans_path, method: :get, local: true do |f| %>
-      <% @questions.each do |question| %>
-        <div class="mb-8">
-          <h3 class="text-brown font-bold mb-2 text-center lg:text-left"><%= question[:question] %></h3>
-          <% question[:options].each_with_index do |option, index| %>
-            <div class="flex items-center space-x-2 justify-center lg:justify-start">
-              <%= radio_button_tag "answers[#{question[:id]}]", option, false, id: "question_#{question[:id]}_option_#{index}", class: 'radio radio-primary radio-xs' %>
-              <%= label_tag "question_#{question[:id]}_option_#{index}", option %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-
-      <div class="flex justify-center lg:justify-start">
-        <%= f.submit "診断結果を表示", class: "btn bg-teal text-white px-6 py-2" %>
-      </div>
+      <%= render 'commons/diagnoses_form', f: f %>
     <% end %>
   </div>
 </body>

--- a/app/views/commons/_diagnoses_form.html.erb
+++ b/app/views/commons/_diagnoses_form.html.erb
@@ -1,0 +1,15 @@
+<% @questions.each do |question| %>
+  <div class="mb-8">
+    <h3 class="text-brown font-bold mb-2 text-center lg:text-left"><%= question[:question] %></h3>
+    <% question[:options].each_with_index do |option, index| %>
+      <div class="flex items-center space-x-2 justify-center lg:justify-start">
+        <%= radio_button_tag "answers[#{question[:id]}]", option, false, id: "question_#{question[:id]}_option_#{index}", class: 'radio radio-primary radio-xs' %>
+        <%= label_tag "question_#{question[:id]}_option_#{index}", option %>
+      </div>
+    <% end %>
+  </div>
+<% end %>
+
+<div class="flex justify-center lg:justify-start">
+  <%= f.submit "診断結果を表示", class: "btn bg-teal text-white px-6 py-2" %>
+</div>

--- a/app/views/desserts/new.html.erb
+++ b/app/views/desserts/new.html.erb
@@ -7,21 +7,7 @@
     </h1>
 
     <%= form_with url: result_desserts_path, method: :get, local: true do |f| %>
-      <% @questions.each do |question| %>
-        <div class="mb-8">
-          <h3 class="text-brown font-bold mb-2 text-center lg:text-left"><%= question[:question] %></h3>
-          <% question[:options].each_with_index do |option, index| %>
-            <div class="flex items-center space-x-2 justify-center lg:justify-start">
-              <%= radio_button_tag "answers[#{question[:id]}]", option, false, id: "question_#{question[:id]}_option_#{index}", class: 'radio radio-primary radio-xs' %>
-              <%= label_tag "question_#{question[:id]}_option_#{index}", option %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-
-      <div class="flex justify-center lg:justify-start">
-        <%= f.submit "診断結果を表示", class: "btn bg-teal text-white px-6 py-2" %>
-      </div>
+      <%= render 'commons/diagnoses_form', f: f %>
     <% end %>
   </div>
 </body>

--- a/app/views/drinks/new.html.erb
+++ b/app/views/drinks/new.html.erb
@@ -7,21 +7,7 @@
     </h1>
 
     <%= form_with url: result_drinks_path, method: :get, local: true do |f| %>
-      <% @questions.each do |question| %>
-        <div class="mb-8">
-          <h3 class="text-brown font-bold mb-2 text-center lg:text-left"><%= question[:question] %></h3>
-          <% question[:options].each_with_index do |option, index| %>
-            <div class="flex items-center space-x-2 justify-center lg:justify-start">
-              <%= radio_button_tag "answers[#{question[:id]}]", option, false, id: "question_#{question[:id]}_option_#{index}", class: 'radio radio-primary radio-xs' %>
-              <%= label_tag "question_#{question[:id]}_option_#{index}", option %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-
-      <div class="flex justify-center lg:justify-start">
-        <%= f.submit "診断結果を表示", class: "btn bg-teal text-white px-6 py-2" %>
-      </div>
+      <%= render 'commons/diagnoses_form', f: f %>
     <% end %>
   </div>
 </body>


### PR DESCRIPTION
## 概要
各診断ページの診断フォームのコンポーネント作成をしました。

## 変更内容
- コーヒー豆診断フォームのコンポーネント作成(`app/views/coffee_beans/new.html.erb`)
- カフェドリンク診断フォームのコンポーネント作成(`app/views/drinks/new.html.erb`)
- カフェデザート診断フォームのコンポーネント作成(`app/views/desserts/new.html.erb`)
- 診断フォームのコンポーネント化(`app/views/commons/_diagnoses_form.html.erb`)