### PR TITLE
投稿一覧・詳細ページのコンポーネント作成・導入

### DIFF
--- a/app/views/posts/components/_action_button.html.erb
+++ b/app/views/posts/components/_action_button.html.erb
@@ -1,0 +1,12 @@
+<div class="flex items-center space-x-4">
+  <% if current_user&.mine?(@post) %>
+    <%= link_to edit_post_path(@post) do %>
+      <i class="fa-regular fa-pen-to-square fa-xl md:fa-2xl text-brown"></i>
+    <% end %>
+    <%= link_to post_path(@post), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
+      <i class="fa-regular fa-trash-can fa-xl md:fa-2xl text-brown"></i>
+    <% end %>
+  <% else %>
+    <%= render 'bookmark_buttons', { post: @post } %>
+  <% end %>
+</div>

--- a/app/views/posts/components/_address.html.erb
+++ b/app/views/posts/components/_address.html.erb
@@ -1,0 +1,4 @@
+<div class="flex items-center mb-4">
+  <i class="fa-solid fa-location-dot fa-xl mr-2 text-brown"></i>
+  <p class="text-gray-700 text-sm md:text-base"><%= @post.address %></p>
+</div>

--- a/app/views/posts/components/_avatar_nickname.html.erb
+++ b/app/views/posts/components/_avatar_nickname.html.erb
@@ -1,0 +1,10 @@
+<%= link_to account_path(@post.user), class: 'flex items-center' do %>
+  <div class="flex items-center mb-2">
+    <% if @post.user.profile&.avatar&.attached? %>
+      <%= image_tag url_for(@post.user.profile.avatar), class: 'w-8 h-8 rounded-full mr-2' %>
+    <% else %>
+      <i class="fa-regular fa-circle-user fa-xl text-brown mr-2"></i>
+    <% end %>
+    <p class="text-gray-700 font-bold hover:opacity-70 text-sm md:text-base"><%= @post.user.profile&.nickname || @post.user.display_name %></p>
+  </div>
+<% end %>

--- a/app/views/posts/components/_cafe_link.html.erb
+++ b/app/views/posts/components/_cafe_link.html.erb
@@ -1,0 +1,9 @@
+<div class="flex items-center mb-8 hover:opacity-70">
+  <i class="fa-solid fa-link fa-xl text-brown mr-2"></i>
+  <% cafe_link = @post.cafe_link.to_s.strip %>
+  <% if cafe_link.present? && cafe_link =~ /\Ahttps?:\/\/[^\s]+\z/ %>
+    <%= link_to ERB::Util.html_escape(cafe_link), cafe_link, target: "_blank", rel: "noopener noreferrer", class: "link link-neutral text-sm md:text-md truncate overflow-hidden text-ellipsis" %>
+  <% else %>
+    <span class="text-gray-500 text-sm md:text-md">リンクは無効です</span>
+  <% end %>
+</div>

--- a/app/views/posts/components/_comments.html.erb
+++ b/app/views/posts/components/_comments.html.erb
@@ -1,0 +1,34 @@
+<div class="bg-white md:bg-cream p-4 rounded-xl">
+  <div class="mt-2 mb-4 ml-2 flex items-center ">
+    <div class="flex items-center">
+      <i class="fa-solid fa-comment fa-xl mr-2 text-brown"></i>
+      <h2 class="text-brown text-lg md:text-xl font-bold">コメント</h2>
+    </div>
+
+    <%= link_to new_post_comment_path(@post) do %>
+      <div class="flex items-center cursor-pointer hover:opacity-70 ml-6">
+        <i class="fa-solid fa-comment-medical fa-lg text-brown"></i>
+        <span class="ml-2 text-sm md:text-base text-gray-700 font-bold">コメントを追加</span>
+      </div>
+    <% end %>
+  </div>
+
+<div class="divider"></div>
+<% @comments.each do |comment| %>
+  <div class="md:flex md:items-center text-gray-600 bg-cream md:bg-white px-6 py-4 mb-4 rounded-xl">
+    <p class="flex-1 text-sm md:text-base"><%= comment.content %></p>
+    <span class="text-gray-500 text-xs md:text-sm md:ml-4 mr-2">
+      <%= link_to comment.user.profile&.nickname || comment.user.display_name, account_path(comment.user), class: 'text-brown hover:underline' %>
+    </span>
+    <% if current_user == comment.user %>
+      <div class="md:ml-4 flex items-center space-x-2">
+        <%= link_to edit_post_comment_path(@post, comment) do %>
+          <i class="fa-regular fa-pen-to-square md:fa-lg text-brown"></i>
+        <% end %>
+        <%= button_to post_comment_path(comment.post.id, comment.id), method: :delete do %>
+          <i class="fa-regular fa-trash-can md:fa-lg text-brown"></i>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/posts/components/_goggle_map_display.html.erb
+++ b/app/views/posts/components/_goggle_map_display.html.erb
@@ -1,0 +1,37 @@
+<script type="text/javascript">
+    function initMap() {
+      var test = {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>};
+      var map = new google.maps.Map(document.getElementById('map'), {
+                zoom: 15,
+                center: test
+      });
+      var transitLayer = new google.maps.TransitLayer();
+      transitLayer.setMap(map);
+
+      var contentString = '住所：<%= @post.address %>';
+      var infowindow = new google.maps.InfoWindow({
+        content: contentString
+      });
+
+      var marker = new google.maps.Marker({
+                    position: test,
+                    map: map,
+                    title: contentString
+                    });
+
+        marker.addListener('click', function() {
+          infowindow.open(map, marker);
+        });
+    }
+  </script>
+  <script async
+          src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap">
+  </script>
+  <style type="text/css">
+    #map {
+      height: 300px;
+      width: 100%;
+      max-width: 700px;
+    }
+  </style>
+  <div id="map"></div>

--- a/app/views/posts/components/_image.html.erb
+++ b/app/views/posts/components/_image.html.erb
@@ -1,0 +1,3 @@
+<% if @post.image.attached? %>
+  <%= image_tag @post.image, class: 'w-full max-w-md h-auto mb-8' %>
+<% end %>

--- a/app/views/posts/components/_new_post_button.html.erb
+++ b/app/views/posts/components/_new_post_button.html.erb
@@ -1,0 +1,5 @@
+<%= link_to new_post_path do %>
+  <div class="bg-teal border-4 border-white p-4 rounded-full shadow-lg fixed bottom-4 right-4 flex items-center justify-center w-16 h-16">
+    <i class="fa fa-plus text-white text-2xl"></i>
+  </div>
+<% end %>

--- a/app/views/posts/components/_tags.html.erb
+++ b/app/views/posts/components/_tags.html.erb
@@ -1,0 +1,10 @@
+<div class="mt-6 mb-8">
+  <% @post.tags.each do |tag| %>
+    <div class="text-brown mr-3 hover:opacity-70">
+    <%= link_to tag_path(tag) do %>
+      <i class="fa-solid fa-hashtag"></i>
+      <span class="text-sm md:text-base"><%= tag.name %></span>
+    <% end %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/posts/components/_x_share.html.erb
+++ b/app/views/posts/components/_x_share.html.erb
@@ -1,0 +1,12 @@
+ <div class="text-brown">
+  <% prepare_meta_tags @post %>
+  <% timestamp = Time.now.to_i %>
+  <% share_url = post_url(@post, protocol: 'https') %>
+  <% nickname = @post.user.profile&.nickname || @post.user.display_name %>
+  <% twitter_share_url = "https://twitter.com/share?text=#{CGI.escape("#{nickname}さんが#{@post.cafe_name}を投稿したよ！- #magco")}&url=#{share_url}" %>
+
+  <%= link_to twitter_share_url, target: '_blank', class: "flex items-center mb-8 hover:opacity-70", title: "Xでシェア" do %>
+    <i class="fa-brands fa-x-twitter fa-xl mr-2"></i>
+    <span class="text-gray-700 font-bold text-sm md:text-base">Xに共有する</span>
+  <% end %>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,18 +1,10 @@
 <% content_for(:title, t('.title')) %>
 <div class="container mx-auto pt-10 md:px-0 px-6">
-
 <%= render 'commons/search_form', search_url: posts_path %>
-
 <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 pt-8 pb-8">
   <% @posts.each do |post| %>
       <%= render 'commons/post', post: post %>
   <% end %>
 </div>
-
 <%= paginate @posts %>
-
-<%= link_to new_post_path do %>
-  <div class="bg-teal border-4 border-white p-4 rounded-full shadow-lg fixed bottom-2 right-2 flex items-center justify-center w-16 h-16 hover:opacity-70">
-    <i class="fa fa-plus text-white text-2xl"></i>
-  </div>
-<% end %>
+<%= render 'posts/components/new_post_button' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,165 +1,20 @@
 <% content_for(:title, @cafe_name) %>
 <body class="bg-cream">
   <div class="container mx-auto px-6 md:px-10 py-8 my-8 md:bg-white rounded-xl min-h-screen max-w-screen-lg">
-
- <div class="flex justify-between items-center mb-4">
-  <!-- Cafe Name (Left side) -->
-  <h1 class="text-xl md:text-2xl font-bold text-brown w-auto"><%= @post.cafe_name %></h1>
-
-  <!-- Action Buttons (Right side) -->
-  <div class="flex items-center space-x-4">
-    <% if current_user&.mine?(@post) %>
-      <%= link_to edit_post_path(@post) do %>
-        <i class="fa-regular fa-pen-to-square fa-xl md:fa-2xl text-brown"></i>
-      <% end %>
-      <%= link_to post_path(@post), data: { turbo_method: :delete, turbo_confirm: '削除しますか？' } do %>
-        <i class="fa-regular fa-trash-can fa-xl md:fa-2xl text-brown"></i>
-      <% end %>
-    <% else %>
-      <%= render 'bookmark_buttons', { post: @post } %>
-    <% end %>
-  </div>
-</div>
-
-
-
-    <%= link_to account_path(@post.user), class: 'flex items-center' do %>
-      <div class="flex items-center mb-2">
-        <% if @post.user.profile&.avatar&.attached? %>
-          <%= image_tag url_for(@post.user.profile.avatar), class: 'w-8 h-8 rounded-full mr-2' %>
-        <% else %>
-          <i class="fa-regular fa-circle-user fa-xl text-brown mr-2"></i>
-        <% end %>
-        <p class="text-gray-700 font-bold hover:opacity-70 text-sm md:text-base"><%= @post.user.profile&.nickname || @post.user.display_name %></p>
-      </div>
-    <% end %>
+    <div class="flex justify-between items-center mb-4">
+      <h1 class="text-xl md:text-2xl font-bold text-brown w-auto"><%= @post.cafe_name %></h1>
+      <%= render 'posts/components/action_button' %>
+    </div>
+    <%= render 'posts/components/avatar_nickname' %>
     <p class="text-gray-500 mb-4 text-sm md:text-base"><%= @post.created_at.strftime("%Y/%m/%d %H:%M") %></p>
-
     <p class="text-gray-700 md:text-xl mb-8"><%= @post.body %></p>
-    <% if @post.image.attached? %>
-      <%= image_tag @post.image, class: 'w-full max-w-md h-auto mb-8' %>
-    <% end %>
-
-    <div class="flex items-center mb-4">
-      <i class="fa-solid fa-location-dot fa-xl mr-2 text-brown"></i>
-      <p class="text-gray-700 text-sm md:text-base"><%= @post.address %></p>
-    </div>
-
-    <!-- Google Map Embed -->
-    <script type="text/javascript">
-      function initMap() {
-        var test = {lat: <%= @post.latitude %>, lng: <%= @post.longitude %>};
-        var map = new google.maps.Map(document.getElementById('map'), {
-                  zoom: 15,
-                  center: test
-        });
-        var transitLayer = new google.maps.TransitLayer();
-        transitLayer.setMap(map);
-
-        var contentString = '住所：<%= @post.address %>';
-        var infowindow = new google.maps.InfoWindow({
-          content: contentString
-        });
-
-        var marker = new google.maps.Marker({
-                      position: test,
-                      map: map,
-                      title: contentString
-                     });
-
-         marker.addListener('click', function() {
-           infowindow.open(map, marker);
-         });
-      }
-    </script>
-    <script async
-            src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=<%= ENV['GOOGLE_MAP_API_KEY'] %>&callback=initMap">
-    </script>
-    <style type="text/css">
-      #map {
-        height: 300px;
-        width: 100%;
-        max-width: 700px;
-      }
-    </style>
-    <div id="map"></div>
-
-    <div class="mt-6 mb-8">
-      <% @post.tags.each do |tag| %>
-        <div class="text-brown mr-3 hover:opacity-70">
-        <%= link_to tag_path(tag) do %>
-          <i class="fa-solid fa-hashtag"></i>
-          <span class="text-sm md:text-base"><%= tag.name %></span>
-        <% end %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="flex items-center mb-8 hover:opacity-70">
-      <i class="fa-solid fa-link fa-xl text-brown mr-2"></i>
-      <% cafe_link = @post.cafe_link.to_s.strip %>
-      <% if cafe_link.present? && cafe_link =~ /\Ahttps?:\/\/[^\s]+\z/ %>
-        <%= link_to ERB::Util.html_escape(cafe_link), cafe_link, target: "_blank", rel: "noopener noreferrer", class: "link link-neutral text-sm md:text-md truncate overflow-hidden text-ellipsis" %>
-      <% else %>
-        <span class="text-gray-500 text-sm md:text-md">リンクは無効です</span>
-      <% end %>
-    </div>
-
-    <%= link_to new_post_path do %>
-      <div class="bg-teal border-4 border-white p-4 rounded-full shadow-lg fixed bottom-4 right-4 flex items-center justify-center w-16 h-16">
-        <i class="fa fa-plus text-white text-2xl"></i>
-      </div>
-    <% end %>
-
-    <div class="text-brown">
-      <% prepare_meta_tags @post %>
-      <% timestamp = Time.now.to_i %>
-      <% share_url = post_url(@post, protocol: 'https') %>
-      <% nickname = @post.user.profile&.nickname || @post.user.display_name %>
-      <% twitter_share_url = "https://twitter.com/share?text=#{CGI.escape("#{nickname}さんが#{@post.cafe_name}を投稿したよ！- #magco")}&url=#{share_url}" %>
-
-      <%= link_to twitter_share_url, target: '_blank', class: "flex items-center mb-8 hover:opacity-70", title: "Xでシェア" do %>
-        <i class="fa-brands fa-x-twitter fa-xl mr-2"></i>
-        <span class="text-gray-700 font-bold text-sm md:text-base">Xに共有する</span>
-      <% end %>
-    </div>
-
-    <div class="bg-white md:bg-cream p-4 rounded-xl">
-      <div class="mt-2 mb-4 ml-2 flex items-center ">
-        <div class="flex items-center">
-          <i class="fa-solid fa-comment fa-xl mr-2 text-brown"></i>
-          <h2 class="text-brown text-lg md:text-xl font-bold">コメント</h2>
-        </div>
-
-     <%= link_to new_post_comment_path(@post) do %>
-        <div class="flex items-center cursor-pointer hover:opacity-70 ml-6">
-          <i class="fa-solid fa-comment-medical fa-lg text-brown"></i>
-          <span class="ml-2 text-sm md:text-base text-gray-700 font-bold">コメントを追加</span>
-        </div>
-      <% end %>
-    </div>
-
-
-      <div class="divider"></div>
-
-      <% @comments.each do |comment| %>
-        <div class="md:flex md:items-center text-gray-600 bg-cream md:bg-white px-6 py-4 mb-4 rounded-xl">
-          <p class="flex-1 text-sm md:text-base"><%= comment.content %></p>
-          <span class="text-gray-500 text-xs md:text-sm md:ml-4 mr-2">
-            <%= link_to comment.user.profile&.nickname || comment.user.display_name, account_path(comment.user), class: 'text-brown hover:underline' %>
-          </span>
-          <% if current_user == comment.user %>
-            <div class="md:ml-4 flex items-center space-x-2">
-              <%= link_to edit_post_comment_path(@post, comment) do %>
-                <i class="fa-regular fa-pen-to-square md:fa-lg text-brown"></i>
-              <% end %>
-              <%= button_to post_comment_path(comment.post.id, comment.id), method: :delete do %>
-                <i class="fa-regular fa-trash-can md:fa-lg text-brown"></i>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-    </div>
+    <%= render 'posts/components/image' %>
+    <%= render 'posts/components/address' %>
+    <%= render 'posts/components/goggle_map_display' %>
+    <%= render 'posts/components/tags' %>
+    <%= render 'posts/components/cafe_link' %>
+    <%= render 'posts/components/x_share' %>
+    <%= render 'posts/components/comments' %>
   </div>
+  <%= render 'posts/components/new_post_button' %>
 </body>


### PR DESCRIPTION
## 概要
投稿一覧・詳細ページのコンポーネント作成しました。

## 変更内容
- 投稿一覧・詳細ページのコンポーネント作成(`app/views/posts/components/_action_button.html.erb`・`app/views/posts/components/_address.html.erb`・`app/views/posts/components/_avatar_nickname.html.erb`・`app/views/posts/components/_cafe_link.html.erb`・`app/views/posts/components/_comments.html.erb`・`app/views/posts/components/_goggle_map_display.html.erb`・`app/views/posts/components/_image.html.erb`・`app/views/posts/components/_new_post_button.html.erb`・`app/views/posts/components/_tags.html.erb`・`app/views/posts/components/_x_share.html.erb`)
- 投稿一覧ページのコンポーネント化(`app/views/posts/index.html.erb`)
- 投稿詳細ページのコンポーネント化(`app/views/posts/show.html.erb`)