### PR TITLE
fix:postsテーブルのadrressカラムのバリデーション変更

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,7 @@ class Post < ApplicationRecord
   validates :cafe_name, presence: true, length: { minimum: 2, maximum: 100 }
   validates :body, presence: true, length: { minimum: 10, maximum: 2000 }
   validates :address, presence: true, length: { minimum: 2, maximum: 100 }
-  validates :cafe_link, format: { with: URI::regexp(%w[http https]), allow_blank: true },length: { minimum: 5, maximum: 150 }
+  validates :cafe_link, format: { with: URI::regexp(%w[http https]), allow_blank: true },length: { maximum: 150 }
 
   belongs_to :user
   has_many :comments, dependent: :destroy

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,8 @@
 class Post < ApplicationRecord
   validates :cafe_name, presence: true, length: { minimum: 2, maximum: 100 }
   validates :body, presence: true, length: { minimum: 10, maximum: 2000 }
-  validates :address, presence: true, length: { minimum: 2, maximum: 50 }
-  validates :cafe_link, format: { with: URI::regexp(%w[http https]), allow_blank: true }
+  validates :address, presence: true, length: { minimum: 2, maximum: 100 }
+  validates :cafe_link, format: { with: URI::regexp(%w[http https]), allow_blank: true },length: { minimum: 5, maximum: 150 }
 
   belongs_to :user
   has_many :comments, dependent: :destroy

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -17,7 +17,7 @@
     コメント
     <span class="text-red-500 ml-1">*</span>
   <% end %>
-  <%= f.text_area :body, placeholder:'10文字以上', class: 'border border-gray-200 rounded-lg w-full p-2 h-32' %>
+  <%= f.text_area :body, class: 'border border-gray-200 rounded-lg w-full p-2 h-32' %>
 </div>
 
 <div class="divider"></div>
@@ -28,7 +28,7 @@
 </div>
 
 <div class="mb-4">
-  <%= f.label :cafe_link, 'URL', class: 'block text-brown font-semibold mb-2' %>
+  <%= f.label :cafe_link, 'カフェのURL', class: 'block text-brown font-semibold mb-2' %>
   <%= f.text_field :cafe_link, class: 'border border-gray-200 rounded-lg w-full p-2' %>
 </div>
 

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Post, type: :model do
         expect(post).to be_invalid
       end
 
-      it '51文字の場合は無効であること' do
-        post.address = 'A' * 51
+      it '101文字の場合は無効であること' do
+        post.address = 'A' * 101
         expect(post).to be_invalid
       end
     end


### PR DESCRIPTION
## 概要

- FBとして、`posts`テーブルの`adrress`カラムの文字上限のバリデーションをもう少し緩めて欲しいとのことだったので以下に変更
```
[before]2文字以上50文字以内　→　[after]2文字以上100文字以内
```
- `posts`テーブルの`cafe_link`カラムの文字上限のバリデーションを変更
```
[before]上限なし　→　[after]150文字以内
```
- カフェ投稿フォームに記述されていた`placeholder`の削除

## 変更内容
- `adreess`・`cafe_link`カラムのバリデーション変更(`app/models/post.rb`)
- カフェ投稿フォームの`placeholder`を削除(`app/views/posts/_form.html.erb`)
